### PR TITLE
Fixes context test fail

### DIFF
--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -156,7 +156,7 @@ public class AddTask extends Activity {
 					int position, long id) {
 				if (position > 0) {
 					String item = contextsArr.get(position);
-					text.append("@" + item + " ");
+					text.append(" @" + item);
 				}
 			}
 

--- a/src/com/todotxt/todotxttouch/TaskHelper.java
+++ b/src/com/todotxt/todotxttouch/TaskHelper.java
@@ -53,7 +53,7 @@ public class TaskHelper {
 	private final static Pattern prioPattern = Pattern
 			.compile("\\(([A-Z])\\) (.*)");
 
-	private final static Pattern contextPattern = Pattern.compile("@(\\w+)");
+	private final static Pattern contextPattern = Pattern.compile("(?:^|\\s)@(\\w+)");
 
 	private final static Pattern projectPattern = Pattern.compile("\\+(\\w+)");
 

--- a/tests/src/com/todotxt/todotxttouch/test/TodoUtilTest.java
+++ b/tests/src/com/todotxt/todotxttouch/test/TodoUtilTest.java
@@ -136,6 +136,24 @@ public class TodoUtilTest extends TestCase {
 		assertEquals("Wrong context", "phone", createdTask.contexts.get(0));
 	}
 	
+	/*
+	 * Ensure that a context can be properly parsed out from a string if it's at the start
+	 */
+	public void testCreateTaskWithContextAtStart() {
+		int expectedId = 1;
+		char expectedPriority = '-';
+		String expectedString = "@work Complete a simple programming task";
+		
+		Task createdTask = TaskHelper.createTask(expectedId, expectedString);
+		
+		assertEquals("ID's are equal", expectedId, createdTask.id);
+		assertEquals("Priorities are equal", expectedPriority, createdTask.prio);
+		assertEquals("Text is equal", expectedString, createdTask.text);
+		
+		assertEquals("Wrong number of contexts", 1, createdTask.contexts.size());
+		assertEquals("Wrong context", "work", createdTask.contexts.get(0));
+	}
+	
 	public void testCreateTaskDistinguishContextFromEmail() {
 		int expectedId = 1;
 		char expectedPriority = '-';


### PR DESCRIPTION
As noted earlier, a test failed, indicating that email addresses were marked/detected as contexts.

This fixes that, making sure that contexts must have a whitespace (or be at the start of a line)

This also fixes a bug where add/edit task added the context with a space at the end instead of before the context, resulting in tasks like: "(A) This is a test with a context@contextname ". This would not be recognized as a task after the aforementioned fix.

Yours
