### PR TITLE
54 prioritize menu misses option

### DIFF
--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -330,7 +330,7 @@ public class TodoTxtTouch extends ListActivity implements
 			Util.showConfirmationDialog(this, R.string.areyousure, listener);
 		} else if (menuid == R.id.priority) {
 			Log.v(TAG, "priority");
-			final String[] prioArr = { "" + TaskHelper.NONE, "A", "B", "C" };
+			final String[] prioArr = { "" + TaskHelper.NONE, "A", "B", "C", "D" };
 			AlertDialog.Builder builder = new AlertDialog.Builder(this);
 			builder.setTitle("Select priority");
 			builder.setSingleChoiceItems(prioArr, 0, new OnClickListener() {


### PR DESCRIPTION
Fixes #54. Quick, simple fix. It came up right before the last pull, but it is just an "D" added in an unrelated file, so it should come in clean.

Not sure if it was worth a commit/branch doing this, but it took 2 minutes, so I felt it wasn't worth not doing when it closes an issue.
