### PR TITLE
Fixes crash on context change while in AsyncTask

### DIFF
--- a/src/com/todotxt/todotxttouch/Util.java
+++ b/src/com/todotxt/todotxttouch/Util.java
@@ -62,7 +62,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 public class Util {
-
+	
 	private static String TAG = Util.class.getSimpleName();
 
 	private static final int CONNECTION_TIMEOUT = 120000;
@@ -157,7 +157,7 @@ public class Util {
 			closeStream(os);
 		}
 	}
-
+	
 	public static void showToastLong(Context cxt, int resid) {
 		Toast.makeText(cxt, resid, Toast.LENGTH_LONG).show();
 	}


### PR DESCRIPTION
See Issue #100 for more details.

Passing AsyncTask the proper variables so it can keep track of what it needs to through a context change was easy. The tricky part was at the end of the AsyncTask dismissing the ProgressDialog. If a context change happened while AsyncTask was running that ProgressDialog no longer exists so AsyncTask trying to dismiss it created another error. Meanwhile the new ProgressDialog created after the context change was completed is never dismissed! So I created a method that allows whatever the current ProgressDialog is to be dismissed so tasks running on other threads don't have to keep track of the reference to the current ProgressDialog. 
