### PR TITLE
Filter search bug

### DIFF
--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -801,7 +801,7 @@ public class TodoTxtTouch extends ListActivity implements
 				holder = (ViewHolder) convertView.getTag();
 			}
 
-			Task task = taskBag.getTasks().get(position);
+			Task task = m_adapter.getItem(position);// taskBag.getTasks().get(position);
 			if (task != null) {
 				holder.taskid.setText(String.format("%02d", task.getId() + 1));
 				holder.taskprio.setText(task.getPriority().inListFormat());


### PR DESCRIPTION
This fixes mentioned filter bug.

There is another instance of the empty getTasks() called, but that is in TodoTxtTouch.onCreate. This should not be a problem until/if we save filters to preferences. Which we probably won't do. Filter works after escaping to home screen and relaunching TodoTxtTouch.
