### PR TITLE
145 go offline when no network rc

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -89,4 +89,5 @@ You should have received a copy of the GNU General Public License along with Tod
 				android:resource="@xml/searchable" />
 		</activity>
 	</application>
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
 </manifest> 

--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -86,7 +86,6 @@ public class AddTask extends Activity {
 		final Intent intent = getIntent();
 		final String action = intent.getAction();
 		// create shortcut and exit
-		// create shortcut and exit
 		if (Intent.ACTION_CREATE_SHORTCUT.equals(action)) {
 			Log.d(TAG, "Setting up shortcut icon");
 			setupShortcut();
@@ -235,47 +234,53 @@ public class AddTask extends Activity {
 				final String input = textInputField.getText().toString()
 						.replaceAll("\\r\\n|\\r|\\n", " ");
 
-				new AsyncTask<Object, Void, Boolean>() {
-					protected void onPreExecute() {
-						m_ProgressDialog = ProgressDialog.show(AddTask.this,
-								getTitle(), "Please wait...", true);
-					}
-
-					@Override
-					protected Boolean doInBackground(Object... params) {
-						try {
-							Task task = (Task) params[0];
-							String input = (String) params[1];
-							if (task != null) {
-								task.update(input);
-								taskBag.update(task);
-							} else {
-								taskBag.addAsTask(input);
-							}
-							return true;
-						} catch (Exception e) {
-							Log.e(TAG,
-									"input: " + input + " - " + e.getMessage());
-							return false;
-						}
-					}
-
-					protected void onPostExecute(Boolean result) {
-						if (result) {
-							String res = m_backup != null ? getString(R.string.updated_task)
-									: getString(R.string.added_task);
-							Util.showToastLong(AddTask.this, res);
-							finish();
-						} else {
-							String res = m_backup != null ? getString(R.string.update_task_failed)
-									: getString(R.string.add_task_failed);
-							Util.showToastLong(AddTask.this, res);
-						}
-						m_ProgressDialog.dismiss();
-					}
-				}.execute(m_backup, input);
+				addEditAsync(input);
 			}
+
 		});
+	}
+
+	private void addEditAsync(final String input) {
+		new AsyncTask<Object, Void, Boolean>() {
+			protected void onPreExecute() {
+				m_ProgressDialog = ProgressDialog.show(AddTask.this,
+						getTitle(), "Please wait...", true);
+			}
+
+			@Override
+			protected Boolean doInBackground(Object... params) {
+				try {
+					Task task = (Task) params[0];
+					String input = (String) params[1];
+					if (task != null) {
+						task.update(input);
+						taskBag.update(task);
+					} else {
+						taskBag.addAsTask(input);
+					}
+					return true;
+				} catch (Exception e) {
+					Log.e(TAG, "input: " + input + " - " + e.getMessage());
+					return false;
+				}
+			}
+
+			protected void onPostExecute(Boolean result) {
+				if (result) {
+					String res = m_backup != null ? getString(R.string.updated_task)
+							: getString(R.string.added_task);
+					Util.showToastLong(AddTask.this, res);
+					sendBroadcast(new Intent(
+							"com.todotxt.todotxttouch.START_SYNC"));
+					finish();
+				} else {
+					String res = m_backup != null ? getString(R.string.update_task_failed)
+							: getString(R.string.add_task_failed);
+					Util.showToastLong(AddTask.this, res);
+				}
+				m_ProgressDialog.dismiss();
+			}
+		}.execute(m_backup, input);
 	}
 
 	private void setupShortcut() {

--- a/src/com/todotxt/todotxttouch/LoginScreen.java
+++ b/src/com/todotxt/todotxttouch/LoginScreen.java
@@ -31,16 +31,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 
 import com.todotxt.todotxttouch.remote.RemoteClient;
 import com.todotxt.todotxttouch.remote.RemoteLoginTask;
+import com.todotxt.todotxttouch.util.Util;
 
 public class LoginScreen extends Activity {
 
-	final static String TAG = TodoTxtTouch.class.getSimpleName();
+	final static String TAG = LoginScreen.class.getSimpleName();
 
 	private TodoApplication m_app;
 	private Button m_LoginButton;
@@ -76,7 +78,8 @@ public class LoginScreen extends Activity {
 			}
 		});
 
-		final RemoteClient remoteClient = m_app.getRemoteClientManager().getRemoteClient();
+		final RemoteClient remoteClient = m_app.getRemoteClientManager()
+				.getRemoteClient();
 		if (remoteClient.isAuthenticated()) {
 			switchToTodolist();
 		}
@@ -95,16 +98,18 @@ public class LoginScreen extends Activity {
 	}
 
 	void login() {
-		final RemoteClient client = m_app.getRemoteClientManager().getRemoteClient();
+		final RemoteClient client = m_app.getRemoteClientManager()
+				.getRemoteClient();
 
-		if (client.isLoggedIn()) {
-			if ( m_app.getRemoteClientManager().getRemoteClient().authenticate() ) {
-				switchToTodolist();
-			}
+		if (!client.isAvailable()) {
+			Log.d(TAG, "Remote service " + client.getClass().getSimpleName()
+					+ " is not available; aborting login");
+			Util.showToastLong(m_app,
+					"Cannot log in:\nRemote Service not available");
+		} else {
+			RemoteLoginTask loginTask = client.getLoginTask();
+			loginTask.showLoginDialog(this);
 		}
-
-		RemoteLoginTask loginTask = client.getLoginTask();
-		loginTask.showLoginDialog(this);
 	}
 
 }

--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -29,15 +29,18 @@
 package com.todotxt.todotxttouch;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import com.todotxt.todotxttouch.remote.RemoteClientManager;
 import com.todotxt.todotxttouch.task.TaskBag;
 import com.todotxt.todotxttouch.task.TaskBagFactory;
 
 public class TodoApplication extends Application {
-	// private final static String TAG = TodoApplication.class.getSimpleName();
+	private final static String TAG = TodoApplication.class.getSimpleName();
 	public SharedPreferences m_prefs;
 	private RemoteClientManager remoteClientManager;
 	public boolean m_pulling = false;
@@ -63,6 +66,16 @@ public class TodoApplication extends Application {
 
 	public RemoteClientManager getRemoteClientManager() {
 		return remoteClientManager;
+	}
+
+	public boolean isNetworkAvailable() {
+		ConnectivityManager cm = (ConnectivityManager) getApplicationContext()
+				.getSystemService(Context.CONNECTIVITY_SERVICE);
+		boolean networkAvailable = cm.getActiveNetworkInfo() != null
+				&& cm.getActiveNetworkInfo().isConnected();
+		Log.d(TAG, "Checking network availabilty. Network is "
+				+ (networkAvailable ? "" : "not ") + "available.");
+		return networkAvailable;
 	}
 
 }

--- a/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
+++ b/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
@@ -44,7 +44,7 @@ import com.todotxt.todotxttouch.TodoApplication;
 import com.todotxt.todotxttouch.util.Util;
 
 class DropboxRemoteClient implements RemoteClient {
-    private static final String TODO_TXT_REMOTE_FILE_NAME = "todo.txt";
+	private static final String TODO_TXT_REMOTE_FILE_NAME = "todo.txt";
 	private static final File TODO_TXT_TMP_FILE = new File(
 			Environment.getExternalStorageDirectory(),
 			"data/com.todotxt.todotxttouch/tmp/todo.txt");
@@ -52,29 +52,44 @@ class DropboxRemoteClient implements RemoteClient {
 	private DropboxAPI dropboxApi = new DropboxAPI();
 	private TodoApplication todoApplication;
 	private SharedPreferences sharedPreferences;
-    private Config config;
+	private Config config;
 
-	public DropboxRemoteClient(TodoApplication todoApplication, SharedPreferences sharedPreferences) {
+	public DropboxRemoteClient(TodoApplication todoApplication,
+			SharedPreferences sharedPreferences) {
 		this.todoApplication = todoApplication;
 		this.sharedPreferences = sharedPreferences;
 	}
 
-    @Override
-    public Client getClient() {
-        return Client.DROPBOX;
-    }
+	@Override
+	public Client getClient() {
+		return Client.DROPBOX;
+	}
 
 	/**
 	 * Get the stored key - secret pair for authenticating the user
-	 *
+	 * 
 	 * @return a string array with key and secret
 	 */
 	private String[] getAuthToken() {
 		String[] keys = { null, null };
-		keys[0] = sharedPreferences.getString(Constants.PREF_ACCESSTOKEN_KEY, null);
-		keys[1] = sharedPreferences
-				.getString(Constants.PREF_ACCESSTOKEN_SECRET, null);
+		keys[0] = sharedPreferences.getString(Constants.PREF_ACCESSTOKEN_KEY,
+				null);
+		keys[1] = sharedPreferences.getString(
+				Constants.PREF_ACCESSTOKEN_SECRET, null);
 		return keys;
+	}
+
+	/**
+	 * Store the key - secret pair for an authenticated user.
+	 * 
+	 * @param accessTokenKey
+	 * @param accessTokenSecret
+	 */
+	void storeKeys(String accessTokenKey, String accessTokenSecret) {
+		Editor editor = sharedPreferences.edit();
+		editor.putString(Constants.PREF_ACCESSTOKEN_KEY, accessTokenKey);
+		editor.putString(Constants.PREF_ACCESSTOKEN_SECRET, accessTokenSecret);
+		editor.commit();
 	}
 
 	/**
@@ -94,8 +109,8 @@ class DropboxRemoteClient implements RemoteClient {
 
 		String[] userAuthToken = getAuthToken();
 		if (isLoggedIn()) {
-			config = dropboxApi.authenticateToken(userAuthToken[0], userAuthToken[1],
-					config);
+			config = dropboxApi.authenticateToken(userAuthToken[0],
+					userAuthToken[1], config);
 			if (null != config)
 				return true;
 		}
@@ -108,7 +123,7 @@ class DropboxRemoteClient implements RemoteClient {
 	public void deauthenticate() {
 		clearAuthToken();
 		dropboxApi.deauthenticate();
-        TODO_TXT_TMP_FILE.delete();
+		TODO_TXT_TMP_FILE.delete();
 	}
 
 	@Override
@@ -122,47 +137,51 @@ class DropboxRemoteClient implements RemoteClient {
 		return null != userAuthToken[0] && null != userAuthToken[1];
 	}
 
-    @Override
+	@Override
 	public RemoteLoginTask getLoginTask() {
-		return new DropboxLoginAsyncTask(this, sharedPreferences);
+		return new DropboxLoginAsyncTask(this);
 	}
 
-    @Override
-    public File pullTodo( ){
-        DropboxAPI.FileDownload fileDownload = dropboxApi.getFileStream(
-                Constants.DROPBOX_MODUS, getRemotePathAndFilename(), null);
-        if (fileDownload.isError()) {
-            if (404 == fileDownload.httpCode) {
-                pushTodo(TODO_TXT_TMP_FILE);
-                return TODO_TXT_TMP_FILE;
-            } else {
-                throw new DropboxFileRemoteException(
-                        "Error loading from dropbox", fileDownload);
-            }
-        }
+	@Override
+	public File pullTodo() {
+		if (!isAvailable()) {
+			Intent i = new Intent("com.todotxt.todotxttouch.GO_OFFLINE");
+			sendBroadcast(i);
+			return null;
+		}
+		DropboxAPI.FileDownload fileDownload = dropboxApi.getFileStream(
+				Constants.DROPBOX_MODUS, getRemotePathAndFilename(), null);
+		if (fileDownload.isError()) {
+			if (404 == fileDownload.httpCode) {
+				pushTodo(TODO_TXT_TMP_FILE);
+				return TODO_TXT_TMP_FILE;
+			} else {
+				throw new DropboxFileRemoteException(
+						"Error loading from dropbox", fileDownload);
+			}
+		}
 
-        try {
-            Util.writeFile(fileDownload.is, TODO_TXT_TMP_FILE);
-            return TODO_TXT_TMP_FILE;
-        } catch(IOException e) {
-            throw new RemoteException("Error writing to tmp file", e);
-        }
-    }
+		try {
+			Util.writeFile(fileDownload.is, TODO_TXT_TMP_FILE);
+			return TODO_TXT_TMP_FILE;
+		} catch (IOException e) {
+			throw new RemoteException("Error writing to tmp file", e);
+		}
+	}
 
-    @Override
-    public void pushTodo(File file) {
-        try {
-            if(!file.exists()) {
-                Util.createParentDirectory(file);
-                file.createNewFile();
-            }
-        }
-        catch(IOException e) {
-            throw new RemoteException("Failed to ensure that file exists", e);
-        }
+	@Override
+	public void pushTodo(File file) {
+		try {
+			if (!file.exists()) {
+				Util.createParentDirectory(file);
+				file.createNewFile();
+			}
+		} catch (IOException e) {
+			throw new RemoteException("Failed to ensure that file exists", e);
+		}
 
 		dropboxApi.putFile(Constants.DROPBOX_MODUS, getRemotePath(), file);
-    }
+	}
 
 	Config getConfig() {
 		if (null == config)
@@ -174,7 +193,7 @@ class DropboxRemoteClient implements RemoteClient {
 	 * Method enabling logging in with a username and password. Do not store the
 	 * username or password. Config object <code>config</code> will contain user
 	 * key and secret to authenticate w/o username/password later.
-	 *
+	 * 
 	 * @param username
 	 *            - email registered with dropbox
 	 * @param password
@@ -195,21 +214,21 @@ class DropboxRemoteClient implements RemoteClient {
 		return false;
 	}
 
-    void sendBroadcast(Intent intent) {
-        todoApplication.sendBroadcast(intent);
-    }
+	void sendBroadcast(Intent intent) {
+		todoApplication.sendBroadcast(intent);
+	}
 
-    void showToast(String string) {
-        Util.showToastLong(todoApplication, string);
-    }
+	void showToast(String string) {
+		Util.showToastLong(todoApplication, string);
+	}
 
 	DropboxAPI getAPI() {
 		return dropboxApi;
 	}
 
 	String getRemotePath() {
-		return sharedPreferences.getString("todotxtpath", todoApplication.getResources()
-				.getString(R.string.TODOTXTPATH_defaultPath));
+		return sharedPreferences.getString("todotxtpath", todoApplication
+				.getResources().getString(R.string.TODOTXTPATH_defaultPath));
 	}
 
 	String getRemotePathAndFilename() {
@@ -223,8 +242,8 @@ class DropboxRemoteClient implements RemoteClient {
 	private void createConfig() {
 		String consumerKey = todoApplication.getResources()
 				.getText(R.string.dropbox_consumer_key).toString();
-		String consumerSecret = todoApplication.getText(R.string.dropbox_consumer_secret)
-				.toString();
+		String consumerSecret = todoApplication.getText(
+				R.string.dropbox_consumer_secret).toString();
 
 		config = dropboxApi.getConfig(null, false);
 		config.consumerKey = consumerKey;
@@ -232,6 +251,10 @@ class DropboxRemoteClient implements RemoteClient {
 		config.server = "api.dropbox.com";
 		config.contentServer = "api-content.dropbox.com";
 		config.port = 80;
+	}
+
+	public boolean isAvailable() {
+		return todoApplication.isNetworkAvailable();
 	}
 
 }

--- a/src/com/todotxt/todotxttouch/remote/RemoteClient.java
+++ b/src/com/todotxt/todotxttouch/remote/RemoteClient.java
@@ -29,11 +29,11 @@ import java.io.File;
 
 public interface RemoteClient {
 
-    Client getClient();
+	Client getClient();
 
 	/**
 	 * Attempts to authenticate with remote api
-	 *
+	 * 
 	 * @return true if successful
 	 */
 	boolean authenticate();
@@ -45,7 +45,7 @@ public interface RemoteClient {
 
 	/**
 	 * Check to see if we are authenticated with remote api
-	 *
+	 * 
 	 * @return true if authenticated
 	 */
 	boolean isAuthenticated();
@@ -53,27 +53,40 @@ public interface RemoteClient {
 	/**
 	 * Check to see if we have enough information to authenticate with remote
 	 * api
-	 *
+	 * 
+	 * @deprecated This is information internal to the remote service. Will be
+	 *             removed. Use {@link RemoteClient#isAuthenticated()} instead.
 	 * @return true if we have authToken, false if we need login information
 	 */
 	boolean isLoggedIn();
 
 	/**
 	 * Get a login task that can display and handle a login dialog
+	 * 
 	 * @return
 	 */
 	RemoteLoginTask getLoginTask();
 
-    /**
-     * Pull the remote Todo.txt file
-     * @return
-     */
-    File pullTodo();
+	/**
+	 * Pull the remote Todo.txt file
+	 * 
+	 * @return
+	 */
+	File pullTodo();
 
-    /**
-     * Push mobile
-     * @param file
-     */
-    void pushTodo(File file);
+	/**
+	 * Push mobile
+	 * 
+	 * @param file
+	 */
+	void pushTodo(File file);
+
+	/**
+	 * A method to check if the remote service is available (network, sd-card,
+	 * etc)
+	 * 
+	 * @return true if available, false if not
+	 */
+	boolean isAvailable();
 
 }

--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -20,6 +20,7 @@
  * <http://www.gnu.org/licenses/>.
  *
  * @author Tim Barlotta <tim[at]barlotta[dot]net>
+ * @author Tormod Haugen
  * @copyright 2011 Tim Barlotta
  */
 package com.todotxt.todotxttouch.task;
@@ -110,7 +111,6 @@ class TaskBagImpl implements TaskBag {
 					(preferences.isPrependDateEnabled() ? new Date() : null));
 			tasks.add(task);
 			localRepository.store(tasks);
-			pushToRemote();
 		} catch (Exception e) {
 			throw new TaskPersistException("An error occurred while adding {"
 					+ input + "}", e);
@@ -126,7 +126,6 @@ class TaskBagImpl implements TaskBag {
 				task.copyInto(found);
 				Log.i(TAG, "copied into found {" + found + "}");
 				localRepository.store(tasks);
-				pushToRemote();
 			} else {
 				throw new TaskPersistException("Task not found, not updated");
 			}
@@ -144,8 +143,6 @@ class TaskBagImpl implements TaskBag {
 			if (found != null) {
 				tasks.remove(found);
 				localRepository.store(tasks);
-				pushToRemote();
-			} else {
 				throw new TaskPersistException("Task not found, not deleted");
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Todo.txt Touch will go offline when any task that involves dropbox is tried when there is no network access.

Todo.txt Touch will not show a login dialog for dropbox when there is no network access, just politely warn user.

Todo.txt Touch will not leave offline mode when there is no network access

Todo.txt Touch will not ask user about upload/download when there is no network access

Also (from a dev perspective):
1.   Read my comment on #145. I think this closes that, going online "automatically" requires better merge on sync imho.
1.   This asks for the ability to access network state (in AndroidManifest)
1.   This changes the interface around LoginScreen a bit. (code-wise)
1.   Added method #isAvailable to RemoteClient (to check network / storage etc)
1.   Removed (deprecated) method isLoggedIn (this is internal to the servicees, use isAuthenticated)
1.   TaskBag will no longer initiate push after storing local files. This will be asked for after the local storage is complete (in the activity responsible).
