### PR TITLE
Bug tasks cannot be deleted

### DIFF
--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -143,6 +143,7 @@ class TaskBagImpl implements TaskBag {
 			if (found != null) {
 				tasks.remove(found);
 				localRepository.store(tasks);
+			} else {
 				throw new TaskPersistException("Task not found, not deleted");
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Hi,

Got a bit over-zealous with deleting, and deleted the closing of an if block and opening of an else block. This resulted in an exception being thrown when successfully deleting a task - ending in the change not being pushed to remote (dropbox).

Sorry for not testing enough.

I'm not sure how you want to treat this; should I incorporate this fix into the next feature, or keep it in its own branch? Other menu choices tested now. The feature "touch for complete" is ready for trial, I'm testing it out now, and will build a version for me to play with tomorrow... my tomorrow (in 10 hours time).

Yours,

Tormod.
