### PR TITLE
162 clarify upload download

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -120,8 +120,8 @@ You should have received a copy of the GNU General Public License along with Tod
 	<string name="sync_dialog_title">Manual Sync</string>
 	<string name="sync_dialog_msg">Do you want to upload or download your todo.txt
 		file?</string>
-	<string name="sync_dialog_upload">Upload</string>
-	<string name="sync_dialog_download">Download</string>
+	<string name="sync_dialog_upload">Upload changes</string>
+	<string name="sync_dialog_download">Download to phone</string>
 	<string name="sync_upload_message">Uploading todo.txt...</string>
 	<string name="sync_download_message">Downloading todo.txt...</string>
 	<!-- login -->


### PR DESCRIPTION
I have to think every time I switch from offline mode - even though I really know - which way is upload and which way is download.

Added hints ("Upload changes" and "Download to phone"). These should perhaps been in the message text instead ("Do you wish to upload your changes, or download todo.txt to the phone?") - but something has to hint at which way is which.
