### PR TITLE
149 landscape login screen

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,51 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
+<!-- Todo.txt Touch/AndroidManifest.xml Copyright (c) 2009-2011 Gina Trapani, 
+	mathias, Hrayr Artunyan, Stephen Henderson, Tormod Haugen LICENSE: This file 
+	is part of Todo.txt Touch, an Android app for managing your todo.txt file 
+	(http://todotxt.com). Todo.txt Touch is free software: you can redistribute 
+	it and/or modify it under the terms of the GNU General Public License as 
+	published by the Free Software Foundation, either version 2 of the License, 
+	or (at your option) any later version. Todo.txt Touch is distributed in the 
+	hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 
+	warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+	GNU General Public License for more details. You should have received a copy 
+	of the GNU General Public License along with Todo.txt Touch. If not, see 
+	<http://www.gnu.org/licenses/>. @author Gina Trapani <ginatrapani[at]gmail[dot]com> 
+	@author mathias <mathias[at]x2[dot](none)> @author Hrayr Artunyan <hrayr[dot]artunyan[at]gmail[dot]com> 
+	@author Stephen Henderson <me[at]steveh[dot]ca> @author Tormod Haugen <tormodh[at]gmail[dot]com> 
+	@license http://www.gnu.org/licenses/gpl.html @copyright 2009-2011 Gina Trapani, 
+	mathias, Hrayr Artunyan, Stephen Henderson, Tormod Haugen -->
 
-Todo.txt Touch/AndroidManifest.xml
-
-Copyright (c) 2009-2011 Gina Trapani, mathias, Hrayr Artunyan, Stephen Henderson, Tormod Haugen
-
-LICENSE:
-
-This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
-
-Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
-later version.
-
-Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
-<http://www.gnu.org/licenses/>.
-
-@author Gina Trapani <ginatrapani[at]gmail[dot]com>
-@author mathias <mathias[at]x2[dot](none)>
-@author Hrayr Artunyan <hrayr[dot]artunyan[at]gmail[dot]com>
-@author Stephen Henderson <me[at]steveh[dot]ca>
-@author Tormod Haugen <tormodh[at]gmail[dot]com>
-@license http://www.gnu.org/licenses/gpl.html
-@copyright 2009-2011 Gina Trapani, mathias, Hrayr Artunyan, Stephen Henderson, Tormod Haugen
- -->
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.todotxt.todotxttouch" android:versionName="0.6"
-	android:versionCode="20">
+<manifest package="com.todotxt.todotxttouch"
+	android:versionName="0.6" android:versionCode="20"
+	xmlns:android="http://schemas.android.com/apk/res/android">
 	<!-- Warning 'is lower than the project target API level' should be ok -->
 	<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="4" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<application android:name=".TodoApplication" android:icon="@drawable/todotxt_touch_icon"
 		android:label="@string/app_label" android:debuggable="true">
-		<supports-screens android:smallScreens="true"
-			android:normalScreens="true" android:largeScreens="true"
-			android:anyDensity="true" android:resizeable="true" />
+		<uses-configuration></uses-configuration>
+		<supports-screens android:largeScreens="true"
+			android:normalScreens="true" android:smallScreens="true"
+			android:resizeable="true" android:anyDensity="true" />
 
 		<activity android:name=".LoginScreen" android:label="@string/app_label"
 			android:theme="@android:style/Theme.NoTitleBar"
-			android:screenOrientation="portrait">
+			android:configChanges="keyboardHidden|orientation">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -81,7 +69,8 @@ You should have received a copy of the GNU General Public License along with Tod
 		</activity-alias>
 		<activity android:name=".HelpActivity"
 			android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" />
-		<activity android:name=".TodoTxtTouch" android:theme="@android:style/Theme.NoTitleBar" android:configChanges="keyboardHidden|orientation">
+		<activity android:name=".TodoTxtTouch" android:theme="@android:style/Theme.NoTitleBar"
+			android:configChanges="keyboardHidden|orientation">
 			<intent-filter>
 				<action android:name="android.intent.action.SEARCH" />
 			</intent-filter>
@@ -89,5 +78,5 @@ You should have received a copy of the GNU General Public License along with Tod
 				android:resource="@xml/searchable" />
 		</activity>
 	</application>
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
 </manifest> 

--- a/res/layout/login.xml
+++ b/res/layout/login.xml
@@ -48,7 +48,7 @@ You should have received a copy of the GNU General Public License along with Tod
 	android:orientation="horizontal"
 	android:layout_width="wrap_content"
 	android:layout_height="wrap_content" 
-	android:layout_gravity="center_horizontal"
+	android:layout_gravity="center_horizontal|top"
 	android:paddingBottom="15pt">
 	
 	<TextView android:id="@+id/title"
@@ -59,6 +59,8 @@ You should have received a copy of the GNU General Public License along with Tod
 		android:typeface="monospace"
 		android:textColor="@color/white"
 		android:paddingTop="15pt"
+		android:shadowColor="@color/black"
+		android:shadowRadius="1.0"
 	/>
 	<TextView android:id="@+id/title_2"
 		android:layout_width="wrap_content"
@@ -67,6 +69,8 @@ You should have received a copy of the GNU General Public License along with Tod
 		android:textSize="12pt"
 		android:typeface="serif"
 		android:textStyle="italic"
+		android:shadowColor="@color/black"
+		android:shadowRadius="1.0"
 	/>
 	</LinearLayout>
 	


### PR DESCRIPTION
Changed login screen to be oriented when the device is flipped or keyboard is extended.
1.    This is config change only, so if we want the layout to change, those to bits should be unset in order to the layout to be destroyed and recreated.
2.    Added a touch of shadow to the title for it to be more visible when overlapping the logo.
3.    This is just a fix to get it working (technically)
