### PR TITLE
#118: preserve blank lines in file

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -100,4 +100,6 @@ You should have received a copy of the GNU General Public License along with Tod
 	<!-- title bar changes -->
 	<string name="title_search_results">Suchergebnisse für: </string>
 	<string name="title_filter_applied">Angewendeter Filter: </string>
+	<string name="preserve_line_breaks_pref_title">Leere Zeilen behalten</string>
+	<string name="preserve_line_breaks_pref_summary">Die Formatierung der Textdatei beibehalten</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -164,5 +164,8 @@ You should have received a copy of the GNU General Public License along with Tod
 	<string name="toast_notconnected_switch_to_offline">No internet connection!\nSwitching to work offline
 		mode.</string>
 	<string name="short_touch_pref_key">short_touch_pref</string>
+	<string name="preserve_line_breaks_pref_title">Preserve line breaks</string>
+	<string name="preserve_line_breaks_pref_summary">Preserve formatting of the text file</string>
+	<string name="preserve_line_breaks_pref_key">preservelinebreakspref</string>
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -41,6 +41,7 @@ You should have received a copy of the GNU General Public License along with Tod
 			android:title="@string/short_touch_pref_title" android:summary="@string/short_touch_pref_summary_on" />
 		<CheckBoxPreference android:key="@string/line_breaks_pref_key"
 			android:title="@string/line_breaks_pref_title" android:summary="@string/line_breaks_pref_summary" />
+		<CheckBoxPreference android:summary="@string/preserve_line_breaks_pref_summary" android:key="@string/preserve_line_breaks_pref_key" android:title="@string/preserve_line_breaks_pref_title"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory android:key="dropbox_settings"

--- a/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
+++ b/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
@@ -90,6 +90,6 @@ class LocalFileTaskRepository implements LocalTaskRepository {
 	@Override
 	public void store(ArrayList<Task> tasks) {
 		TaskIo.writeToFile(tasks, TODO_TXT_FILE,
-				preferences.isUseWindowsLineBreaksEnabled());
+				preferences.isUseWindowsLineBreaksEnabled(), preferences.isPreserveLineBreaksEnabled());
 	}
 }

--- a/src/com/todotxt/todotxttouch/task/Task.java
+++ b/src/com/todotxt/todotxttouch/task/Task.java
@@ -49,6 +49,7 @@ public class Task implements Serializable {
 	private Priority priority;
 	private boolean deleted = false;
 	private boolean completed = false;
+	private int nextBlankLines = 0;
 	private String text;
 	private String completionDate;
 	private String prependedDate;
@@ -155,6 +156,14 @@ public class Task implements Serializable {
 		return completed;
 	}
 
+	public int getNextBlankLines() {
+		return nextBlankLines;
+	}
+
+	public void setNextBlankLines(int nextBlankLines) {
+		this.nextBlankLines = nextBlankLines;
+	}
+
 	public String getCompletionDate() {
 		return completionDate;
 	}
@@ -214,6 +223,7 @@ public class Task implements Serializable {
 
 	public void copyInto(Task destination) {
 		destination.id = this.id;
+		destination.nextBlankLines = this.nextBlankLines;
 		destination.init(this.inFileFormat(), null);
 	}
 
@@ -246,6 +256,8 @@ public class Task implements Serializable {
 			if (other.links != null)
 				return false;
 		} else if (!links.equals(other.links))
+			return false;
+		if (nextBlankLines != other.nextBlankLines)
 			return false;
 		if (prependedDate == null) {
 			if (other.prependedDate != null)
@@ -284,6 +296,7 @@ public class Task implements Serializable {
 		result = prime * result + (deleted ? 1231 : 1237);
 		result = prime * result + (int) (id ^ (id >>> 32));
 		result = prime * result + ((links == null) ? 0 : links.hashCode());
+		result = prime * result + nextBlankLines;
 		result = prime * result
 				+ ((prependedDate == null) ? 0 : prependedDate.hashCode());
 		result = prime * result

--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -246,6 +246,10 @@ class TaskBagImpl implements TaskBag {
 		public boolean isUseWindowsLineBreaksEnabled() {
 			return sharedPreferences.getBoolean("linebreakspref", false);
 		}
+		
+		public boolean isPreserveLineBreaksEnabled() {
+			return sharedPreferences.getBoolean("preservelinebreakspref", false);
+		}
 
 		public boolean isPrependDateEnabled() {
 			return sharedPreferences.getBoolean("todotxtprependdate", false);


### PR DESCRIPTION
This adds an option to preserve blank lines in the text file. (Issue #118)

I ran into some syncing problems when testing this, but I'm pretty sure those were related to issues #207 and #159, and have nothing to do with what I did.
I think we don't check for changes to the file before adding new items to it (and thereby rewriting it with outdated content).
