### PR TITLE
Per Issue #238, try to initialize new tasks based on our current filters

### DIFF
--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -23,6 +23,7 @@
 package com.todotxt.todotxttouch;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -103,30 +104,46 @@ public class AddTask extends Activity {
 		if (share_text != null) {
 			textInputField.setText(share_text);
 		}
+		
+		Task iniTask = null;
 
 		Task task = (Task) getIntent().getSerializableExtra(
 				Constants.EXTRA_TASK);
 		if (task != null) {
 			m_backup = task;
+			iniTask = m_backup;
 			textInputField.setText(task.inFileFormat());
 			setTitle(R.string.updatetask);
 			titleBarLabel.setText(R.string.updatetask);
 		} else {
 			setTitle(R.string.addtask);
 			titleBarLabel.setText(R.string.addtask);
-		}
 
+			if (textInputField.getText().length() == 0)
+			{
+				@SuppressWarnings("unchecked")
+				ArrayList<Priority> prios = (ArrayList<Priority>)intent.getSerializableExtra(Constants.EXTRA_PRIORITIES_SELECTED);
+				@SuppressWarnings("unchecked")
+				ArrayList<String> contexts = (ArrayList<String>) intent.getSerializableExtra(Constants.EXTRA_CONTEXTS_SELECTED);
+				@SuppressWarnings("unchecked")
+				ArrayList<String> projects = (ArrayList<String>) intent.getSerializableExtra(Constants.EXTRA_PROJECTS_SELECTED);
+
+				iniTask = new Task(1, "");
+				iniTask.initWithFilters(prios, contexts, projects);
+			}
+		}
+		
 		textInputField.setSelection(textInputField.getText().toString()
 				.length());
-
+		
 		// priorities
 		priorities = (Spinner) findViewById(R.id.priorities);
 		final ArrayList<String> prioArr = new ArrayList<String>();
 		prioArr.add("Priority");
 		prioArr.addAll(Priority.rangeInCode(Priority.A, Priority.E));
 		priorities.setAdapter(Util.newSpinnerAdapter(this, prioArr));
-		if (m_backup != null) {
-			int index = prioArr.indexOf(m_backup.getPriority().getCode());
+		if (iniTask != null) {
+			int index = prioArr.indexOf(iniTask.getPriority().getCode());
 			priorities.setSelection(index < 0 ? 0 : index);
 		}
 		priorities.setOnItemSelectedListener(new OnItemSelectedListener() {
@@ -159,6 +176,17 @@ public class AddTask extends Activity {
 		final ArrayList<String> projectsArr = taskBag.getProjects();
 		projectsArr.add(0, "Project");
 		projects.setAdapter(Util.newSpinnerAdapter(this, projectsArr));
+		
+		if (iniTask != null) {
+			List<String> ps = iniTask.getProjects();
+			
+			if ((ps != null) && (ps.size() == 1))
+			{
+				int index = projectsArr.indexOf(ps.get(0));
+				projects.setSelection(index < 0 ? 0 : index);
+			}
+		}
+
 		projects.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(AdapterView<?> arg0, View arg1,
@@ -186,6 +214,17 @@ public class AddTask extends Activity {
 		final ArrayList<String> contextsArr = taskBag.getContexts();
 		contextsArr.add(0, "Context");
 		contexts.setAdapter(Util.newSpinnerAdapter(this, contextsArr));
+		
+		if (iniTask != null) {
+			List<String> cs = iniTask.getContexts();
+			
+			if ((cs != null) && (cs.size() == 1))
+			{
+				int index = contextsArr.indexOf(cs.get(0));
+				contexts.setSelection(index < 0 ? 0 : index);
+			}
+		}
+		
 		contexts.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(AdapterView<?> arg0, View arg1,

--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -778,7 +778,13 @@ public class TodoTxtTouch extends ListActivity implements
 
 	/** Handle "add task" action. */
 	public void onAddTaskClick(View v) {
-		startActivity(new Intent(this, AddTask.class));
+		Intent i = new Intent(this, AddTask.class);
+		
+		i.putExtra(Constants.EXTRA_PRIORITIES_SELECTED, m_prios);
+		i.putExtra(Constants.EXTRA_CONTEXTS_SELECTED, m_contexts);
+		i.putExtra(Constants.EXTRA_PROJECTS_SELECTED, m_projects);
+		
+		startActivity(i);
 	}
 
 	/** Handle "refresh/download" action. */

--- a/src/com/todotxt/todotxttouch/task/Task.java
+++ b/src/com/todotxt/todotxttouch/task/Task.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -312,5 +313,23 @@ public class Task implements Serializable {
 				+ ((relativeAge == null) ? 0 : relativeAge.hashCode());
 		result = prime * result + ((text == null) ? 0 : text.hashCode());
 		return result;
+	}
+
+	public void initWithFilters(ArrayList<Priority> prios,
+			ArrayList<String> ctxts, ArrayList<String> pjs) {
+		if ((prios != null) && (prios.size() == 1))
+		{
+			setPriority(prios.get(0));
+		}
+		if ((ctxts != null) && (ctxts.size() == 1))
+		{
+			contexts.clear();
+			contexts.add(ctxts.get(0));
+		}
+		if ((pjs != null) && (pjs.size() == 1))
+		{
+			projects.clear();
+			projects.add(pjs.get(0));
+		}
 	}
 }

--- a/tests/src/com/todotxt/todotxttouch/task/TaskTest.java
+++ b/tests/src/com/todotxt/todotxttouch/task/TaskTest.java
@@ -25,8 +25,10 @@ package com.todotxt.todotxttouch.task;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import junit.framework.TestCase;
 
@@ -1078,5 +1080,116 @@ public class TaskTest extends TestCase {
 				task.inScreenFormat());
 		assertEquals(expectedResult, task.inFileFormat());
 		assertEquals("", task.getCompletionDate());
+	}
+	
+	public void testFilterInit_nulls() {
+		Task task = new Task(1, "");
+		task.initWithFilters(null, null, null);
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+	}
+
+	public void testFilterInit_empty() {
+		Task task = new Task(1, "");
+		task.initWithFilters(new ArrayList<Priority>(), new ArrayList<String>(), new ArrayList<String>());
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+	}
+	
+	public void testFilterInit_onePriority() {
+		ArrayList<Priority> ps = new ArrayList<Priority>();
+		ps.add(Priority.A);
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(ps, new ArrayList<String>(), new ArrayList<String>());
+		
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+
+		assertEquals("initialized with A", Priority.A, task.getPriority());
+		
+		ps.remove(0);
+		ps.add(Priority.D);
+
+		task = new Task(1, "");
+		task.initWithFilters(ps, new ArrayList<String>(), new ArrayList<String>());
+		
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+
+		assertEquals("initialized with D", Priority.D, task.getPriority());
+	}
+
+	public void testFilterInit_multiPriority() {
+		ArrayList<Priority> ps = new ArrayList<Priority>();
+		ps.add(Priority.A);
+		ps.add(Priority.D);
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(ps, new ArrayList<String>(), new ArrayList<String>());
+		
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+		assertEquals(Priority.NONE, task.getPriority());
+	}
+	
+	public void testFilterInit_oneProject() {
+		ArrayList<String> projects = new ArrayList<String>();
+		projects.add("fred");
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(null, null, projects);
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		
+		List<String> tp = task.getProjects();
+		assertEquals("project count", 1, tp.size());
+		assertEquals("fred", tp.get(0));
+	}
+
+	public void testFilterInit_multiProject() {
+		ArrayList<String> projects = new ArrayList<String>();
+		projects.add("fred");
+		projects.add("barney");
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(null, null, projects);
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+	}
+
+	public void testFilterInit_oneContext() {
+		ArrayList<String> contexts = new ArrayList<String>();
+		contexts.add("quarry");
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(null, contexts, null);
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+		
+		List<String> tc = task.getContexts();
+		assertEquals("context count", 1, tc.size());
+		assertEquals("quarry", tc.get(0));
+	}
+
+	public void testFilterInit_multiContext() {
+		ArrayList<String> contexts = new ArrayList<String>();
+		contexts.add("quarry");
+		contexts.add("home");
+		
+		Task task = new Task(1, "");
+		task.initWithFilters(null, contexts, null);
+		
+		assertEquals(Priority.NONE, task.getPriority());
+		assertEquals(Collections.<String> emptyList(), task.getProjects());
+		assertEquals(Collections.<String> emptyList(), task.getContexts());
 	}
 }


### PR DESCRIPTION
For the context, priority, and project filters - if any of these has _exactly one_ value set, we use those to initialize the new task.  Empty filters, or filters with multiple values (showing "A" and "B" priorities, etc.) have no effect.
