### PR TITLE
FIX 267: Project parser now checks for prepending space

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="lib" path="libs/httpmime-4.0.3.jar"/>
 	<classpathentry kind="lib" path="libs/libphonenumber-4.1.jar"/>
 	<classpathentry kind="lib" path="libs/dropbox-android-sdk-1.2.3.jar"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/src/com/todotxt/todotxttouch/task/ProjectParser.java
+++ b/src/com/todotxt/todotxttouch/task/ProjectParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 class ProjectParser {
 	private final static Pattern CONTEXT_PATTERN = Pattern
-			.compile("\\+(\\S*\\w)");;
+			.compile("(?:^|\\s)\\+(\\S*\\w)");;
 	private static final ProjectParser INSTANCE = new ProjectParser();
 
 	private ProjectParser() {
@@ -47,7 +47,7 @@ class ProjectParser {
 		Matcher m = CONTEXT_PATTERN.matcher(inputText);
 		List<String> projects = new ArrayList<String>();
 		while (m.find()) {
-			String project = m.group(1);
+			String project = m.group(1).trim();
 			projects.add(project);
 		}
 		return projects;

--- a/tests/src/com/todotxt/todotxttouch/task/ProjectParserTest.java
+++ b/tests/src/com/todotxt/todotxttouch/task/ProjectParserTest.java
@@ -70,4 +70,10 @@ public class ProjectParserTest extends TestCase {
 		assertTrue(strings.contains("string"));
 		assertTrue(strings.contains("test"));
 	}
+	
+	public void test_withoutSpace() {
+		String input = "Check out this web site http://example.com/this+is+an+example";
+		List<String> strings = ProjectParser.getInstance().parse(input);
+		assertEquals(0, strings.size());
+	}
 }


### PR DESCRIPTION
This closes issue #267
Projects now need a space in front of them to be parsed.

Also: New Android tools seem to change the .classpath file, also committed it.
