### PR TITLE
Various fixes for syncing

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,12 @@
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry kind="lib" path="libs/apache-mime4j-0.6.jar"/>
+	<classpathentry kind="lib" path="libs/dropbox-android-sdk-1.2.3.jar"/>
+	<classpathentry kind="lib" path="libs/httpmime-4.0.3.jar"/>
+	<classpathentry kind="lib" path="libs/json_simple-1.1.jar"/>
+	<classpathentry kind="lib" path="libs/libphonenumber-4.1.jar"/>
+	<classpathentry kind="lib" path="libs/signpost-commonshttp4-1.2.1.1.jar"/>
+	<classpathentry kind="lib" path="libs/signpost-core-1.2.1.1.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -79,7 +79,7 @@ public class AddTask extends Activity {
 		m_app = (TodoApplication) getApplication();
 		taskBag = m_app.getTaskBag();	
 		
-		sendBroadcast(new Intent(Constants.INTENT_START_SYNC_FROM_REMOTE));
+		sendBroadcast(new Intent(Constants.INTENT_START_SYNC_WITH_REMOTE));
 
 		final Intent intent = getIntent();
 		final String action = intent.getAction();

--- a/src/com/todotxt/todotxttouch/Constants.java
+++ b/src/com/todotxt/todotxttouch/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
 	public static final String PREF_TODO_REV = "todo_rev";
 	public static final String PREF_DONE_REV = "done_rev";
 	public static final String PREF_MANUAL_MODE = "workofflinepref";
+	public static final String PREF_NEED_TO_PUSH = "need_to_push";
 	public static final String DROPBOX_MODUS = "dropbox";
 
 	public final static long INVALID_ID = -1;
@@ -52,6 +53,7 @@ public class Constants {
 	public final static String INTENT_ASYNC_SUCCESS = "com.todotxt.todotxttouch.ASYNC_SUCCESS";
 	public final static String INTENT_ASYNC_FAILED = "com.todotxt.todotxttouch.ASYNC_FAILED";
 	public final static String INTENT_SYNC_CONFLICT = "com.todotxt.todotxttouch.SYNC_CONFLICT";
+	public final static String INTENT_START_SYNC_WITH_REMOTE = "com.todotxt.todotxttouch.START_SYNC";
 	public final static String INTENT_START_SYNC_TO_REMOTE = "com.todotxt.todotxttouch.START_SYNC_TO";
 	public final static String INTENT_START_SYNC_FROM_REMOTE = "com.todotxt.todotxttouch.START_SYNC_FROM";
 	public final static String INTENT_SET_MANUAL = "com.todotxt.todotxttouch.GO_OFFLINE";

--- a/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
+++ b/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
@@ -39,9 +39,12 @@ import com.dropbox.client2.session.Session.AccessType;
 import com.todotxt.todotxttouch.Constants;
 import com.todotxt.todotxttouch.R;
 import com.todotxt.todotxttouch.TodoApplication;
+import com.todotxt.todotxttouch.TodoTxtTouch;
 import com.todotxt.todotxttouch.util.Util;
 
 class DropboxRemoteClient implements RemoteClient {
+	final static String TAG = TodoTxtTouch.class.getSimpleName();
+	
 	private static final String TODO_TXT_REMOTE_FILE_NAME = "todo.txt";
 	private static final String DONE_TXT_REMOTE_FILE_NAME = "done.txt";
 	private static final AccessType ACCESS_TYPE = AccessType.DROPBOX;
@@ -154,9 +157,12 @@ class DropboxRemoteClient implements RemoteClient {
 	 *            The value of the rev to be stored.
 	 */
 	private void storeRev(String key, String rev) {
+		Log.d(TAG, "Storing rev. key=" + key + ". val=" + rev);
 		Editor prefsEditor = sharedPreferences.edit();
 		prefsEditor.putString(key, rev);
-		prefsEditor.commit();
+		if (!prefsEditor.commit()) {
+			Log.e(TAG, "Failed to store rev key! key=" + key + ". val=" + rev);
+		}
 	}
 
 	/**
@@ -174,6 +180,7 @@ class DropboxRemoteClient implements RemoteClient {
 	@Override
 	public PullTodoResult pullTodo() {
 		if (!isAvailable()) {
+			Log.d(TAG, "Offline. Not Pulling.");
 			Intent i = new Intent(Constants.INTENT_SET_MANUAL);
 			sendBroadcast(i);
 			return new PullTodoResult(null, null);

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/TodoTxtTouch"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry kind="lib" path="/TodoTxtTouch/libs/dropbox-android-sdk-1.2.3.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>


### PR DESCRIPTION
- Added some logging in Dropbox logic.\* Check for 404 errors specifically, instead of assuming all errors mean a non-existent remote file.
- Don't assume a need to push unless we have modified a task. At the same time, never assume a need to pull. Added Generic SYNC_WITH_REMOTE intent for those ambiguous cases. That intent's handler will determine based on a persistent flag whether we need to push. The flag is set whenever a push is initiated directly, and cleared when that push succeeds or when a pull is later manually initiated.
- Only sync after a connectivity change if we previously had no connectivity. Otherwise, we were syncing every few seconds. (whenever there was a signal change?)
