### PR TITLE
Dropbox is apparently case-insensitive when it comes to paths.

### DIFF
--- a/src/com/todotxt/todotxttouch/remote/DropboxFileUploader.java
+++ b/src/com/todotxt/todotxttouch/remote/DropboxFileUploader.java
@@ -181,7 +181,7 @@ public class DropboxFileUploader {
 		Log.d(TAG, "Upload succeeded. new rev = " + metadata.rev + ". path = " + metadata.path);
 		
 		file.setLoadedMetadata(metadata);
-		if (!metadata.path.equals(file.getRemoteFile())) {
+		if (!metadata.path.equalsIgnoreCase(file.getRemoteFile())) {
 			// If the uploaded remote path does not match our expected
 			// remotePath,
 			// then a conflict occurred and we should announce the conflict to

--- a/tests/src/com/todotxt/todotxttouch/remote/DropboxFileUploaderTest.java
+++ b/tests/src/com/todotxt/todotxttouch/remote/DropboxFileUploaderTest.java
@@ -176,6 +176,33 @@ public class DropboxFileUploaderTest extends TestCase {
 		assertEquals(remoterev1, dbFile1.getLoadedMetadata().rev);
 	}
 
+	public void testRemoteFileUppercase() {
+		DropboxAPI<?> dropboxapi = new DropboxAPIStub() {
+			public DropboxAPI.Entry metadata(String arg0, int arg1,
+					String arg2, boolean arg3, String arg4)
+					throws DropboxException {
+				return create_metadata(remotefile1, localrev1);
+			}
+
+			public DropboxAPI.Entry putFile(String arg0,
+					InputStream arg1, long arg2, String arg3,
+					ProgressListener arg4) throws DropboxException {
+				return create_metadata(remotefile1.toUpperCase(), remoterev1);
+			}
+		};
+
+		DropboxFileUploader uploader = new DropboxFileUploader(dropboxapi,
+				dropboxFiles1, false);
+
+		uploader.pushFiles();
+		assertEquals("Status should be SUCCESS", DropboxFileStatus.SUCCESS,
+				uploader.getStatus());
+		assertEquals("Should have 1 file", 1, uploader.getFiles().size());
+		assertEquals("Status should be SUCCESS", DropboxFileStatus.SUCCESS,
+				dbFile1.getStatus());
+		assertEquals(remoterev1, dbFile1.getLoadedMetadata().rev);
+	}
+
 	public void testRemoteFileConflict() {
 		DropboxAPI<?> dropboxapi = new DropboxAPIStub() {
 			public DropboxAPI.Entry metadata(String arg0, int arg1,


### PR DESCRIPTION
If you upload 'todo/todo.txt' it will happily replace an existing 'TODO/todo.txt' file if the revs match.
We should ignore files that differ only by case when checking that our uploaded file was
saved with the name we gave it on Dropbox.
