### PR TITLE
Perform push operations synchronously.

### DIFF
--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -43,8 +43,9 @@ public class TodoApplication extends Application {
 	private final static String TAG = TodoApplication.class.getSimpleName();
 	public SharedPreferences m_prefs;
 	private RemoteClientManager remoteClientManager;
-	public boolean m_pulling = false;
-	public boolean m_pushing = false;
+	private boolean m_pulling = false;
+	private boolean m_pushing = false;
+	private int pushQueue = 0;
 	private TaskBag taskBag;
 	private BroadcastReceiver m_broadcastReceiver;
 	private static Context appContext;
@@ -77,8 +78,18 @@ public class TodoApplication extends Application {
 
 	@Override
 	public void onTerminate() {
-		unregisterReceiver(m_broadcastReceiver);
+		if (null != m_broadcastReceiver) {
+			unregisterReceiver(m_broadcastReceiver);
+		}
 		super.onTerminate();
+	}
+	
+	/**
+	 * Are we currently pushing or pulling remote data?
+	 * @return true iff a remote operation currently in progress.
+	 */
+	public boolean syncInProgress() {
+		return m_pulling || m_pushing;
 	}
 
 	/**
@@ -99,6 +110,7 @@ public class TodoApplication extends Application {
 	 * Check network status, then push.
 	 */
 	private void pushToRemote(boolean force, boolean overwrite) {
+		pushQueue += 1;
 		setNeedToPush(true);
 		if (!force && isManualMode()) {
 			Log.i(TAG, "Working offline, don't push now");
@@ -107,12 +119,7 @@ public class TodoApplication extends Application {
 			Log.i(TAG, "Working online; should push if file revisions match");
 			backgroundPushToRemote(overwrite);
 		} else if (m_pulling) {
-			Log.d(TAG, "app is pulling right now. don't start push."); // TODO
-																		// remove
-																		// after
-																		// AsyncTask
-																		// bug
-																		// fixed
+			Log.d(TAG, "app is pulling right now. don't start push."); 
 		} else {
 			Log.i(TAG, "Not connected, don't push now");
 			showToast(R.string.toast_notconnected);
@@ -135,12 +142,7 @@ public class TodoApplication extends Application {
 			Log.i(TAG, "Working online; should pull file");
 			backgroundPullFromRemote();
 		} else if (m_pushing) {
-			Log.d(TAG, "app is pushing right now. don't start pull."); // TODO
-																		// remove
-																		// after
-																		// AsyncTask
-																		// bug
-																		// fixed
+			Log.d(TAG, "app is pushing right now. don't start pull."); 
 		} else {
 			Log.i(TAG, "Not connected, don't pull now");
 			showToast(R.string.toast_notconnected);
@@ -186,56 +188,73 @@ public class TodoApplication extends Application {
 	 */
 	void backgroundPushToRemote(final boolean overwrite) {
 		if (getRemoteClientManager().getRemoteClient().isAuthenticated()) {
-			m_pushing = true;
-			updateSyncUI();
-
-			new AsyncTask<Void, Void, Integer>() {
-				static final int SUCCESS = 0;
-				static final int CONFLICT = 1;
-				static final int ERROR = 2;
-
-				@Override
-				protected Integer doInBackground(Void... params) {
-					try {
-						Log.d(TAG, "start taskBag.pushToRemote");
-						taskBag.pushToRemote(true, overwrite);
-					} catch (RemoteConflictException c) {
-						Log.e(TAG, c.getMessage());
-						return CONFLICT;
-					} catch (Exception e) {
-						Log.e(TAG, e.getMessage());
-						return ERROR;
-					}
-					return SUCCESS;
-				}
-
-				@Override
-				protected void onPostExecute(Integer result) {
-					Log.d(TAG, "post taskBag.pushToremote");
-					if (result == SUCCESS) {
-						Log.d(TAG, "taskBag.pushToRemote done");
-						m_pushing = false;
-						setNeedToPush(false);
-						updateSyncUI();
-						// Push is complete. Now do a pull in case the remote
-						// done.txt has changed.
-						pullFromRemote(true);
-					} else if (result == CONFLICT) {
-						// FIXME: need to know which file had conflict
-						sendBroadcast(new Intent(Constants.INTENT_SYNC_CONFLICT));
-					} else {
-						sendBroadcast(new Intent(Constants.INTENT_ASYNC_FAILED));
-					}
-					super.onPostExecute(result);
-				}
-
-			}.execute();
-
+			if(!(m_pushing || m_pulling)) {
+				new AsyncPushTask(overwrite).execute();
+			}
 		} else {
 			Log.e(TAG, "NOT AUTHENTICATED!");
 			showToast("NOT AUTHENTICATED!");
 		}
+	}
 
+	private class AsyncPushTask extends AsyncTask<Void, Void, Integer> {
+		static final int SUCCESS = 0;
+		static final int CONFLICT = 1;
+		static final int ERROR = 2;
+
+		private boolean overwrite = false;
+		
+		public AsyncPushTask(boolean overwrite) {
+			this.overwrite = overwrite;
+		}
+		
+		@Override
+		protected void onPreExecute() {
+			m_pushing = true;
+			pushQueue = 0;
+			updateSyncUI();
+		}
+		
+		@Override
+		protected Integer doInBackground(Void... params) {
+			try {
+				Log.d(TAG, "start taskBag.pushToRemote");
+				taskBag.pushToRemote(true, overwrite);
+			} catch (RemoteConflictException c) {
+				Log.e(TAG, c.getMessage());
+				return CONFLICT;
+			} catch (Exception e) {
+				Log.e(TAG, e.getMessage());
+				return ERROR;
+			}
+			return SUCCESS;
+		}
+
+		@Override
+		protected void onPostExecute(Integer result) {
+			Log.d(TAG, "post taskBag.pushToremote");
+			m_pushing = false;
+			if (result == SUCCESS) {
+				if (pushQueue > 0) {
+					m_pushing = true;
+					Log.d(TAG, "pushQueue == " + pushQueue + ". Need to push again.");
+					new AsyncPushTask(false).execute();
+				} else {
+					Log.d(TAG, "taskBag.pushToRemote done");
+					setNeedToPush(false);
+					updateSyncUI();
+					// Push is complete. Now do a pull in case the remote
+					// done.txt has changed.
+					pullFromRemote(true);
+				}
+			} else if (result == CONFLICT) {
+				// FIXME: need to know which file had conflict
+				sendBroadcast(new Intent(Constants.INTENT_SYNC_CONFLICT));
+			} else {
+				sendBroadcast(new Intent(Constants.INTENT_ASYNC_FAILED));
+			}
+			super.onPostExecute(result);
+		}
 	}
 
 	/**
@@ -266,9 +285,9 @@ public class TodoApplication extends Application {
 				@Override
 				protected void onPostExecute(Boolean result) {
 					Log.d(TAG, "post taskBag.pullFromRemote");
+					m_pulling = false;
 					if (result) {
 						Log.d(TAG, "taskBag.pullFromRemote done");
-						m_pulling = false;
 						updateSyncUI();
 					} else {
 						sendBroadcast(new Intent(Constants.INTENT_ASYNC_FAILED));

--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -701,8 +701,6 @@ public class TodoTxtTouch extends ListActivity implements
 	 * force an upload or download.
 	 */
 	private void handleSyncConflict() {
-		m_app.m_pushing = false;
-		m_app.m_pulling = false;
 		showDialog(SYNC_CONFLICT_DIALOG);
 	}
 
@@ -991,12 +989,12 @@ public class TodoTxtTouch extends ListActivity implements
 	private void updateSyncUI() {
 		// hide action bar
 		findViewById(R.id.actionbar).setVisibility(View.GONE);
-		// hide refresh button
+		// show or hide refresh button
 		findViewById(R.id.btn_title_refresh).setVisibility(
-				m_app.m_pulling || m_app.m_pushing ? View.GONE : View.VISIBLE);
-		// show moving refresh indicator
+				m_app.syncInProgress() ? View.GONE : View.VISIBLE);
+		// show or hide moving refresh indicator
 		findViewById(R.id.title_refresh_progress).setVisibility(
-				m_app.m_pulling || m_app.m_pushing ? View.VISIBLE : View.GONE);
+				m_app.syncInProgress() ? View.VISIBLE : View.GONE);
 		setFilteredTasks(false);
 	}
 

--- a/tests/src/com/todotxt/todotxttouch/test/RemoteClientManagerStub.java
+++ b/tests/src/com/todotxt/todotxttouch/test/RemoteClientManagerStub.java
@@ -1,0 +1,88 @@
+package com.todotxt.todotxttouch.test;
+
+import java.io.File;
+
+import android.preference.PreferenceManager;
+
+import com.todotxt.todotxttouch.TodoApplication;
+import com.todotxt.todotxttouch.remote.Client;
+import com.todotxt.todotxttouch.remote.PullTodoResult;
+import com.todotxt.todotxttouch.remote.RemoteClient;
+import com.todotxt.todotxttouch.remote.RemoteClientManager;
+
+public class RemoteClientManagerStub extends RemoteClientManager {
+
+	private RemoteClient remoteClient = new RemoteClientStub();
+	
+	public RemoteClientManagerStub(TodoApplication todoApplication) {
+		super(todoApplication, PreferenceManager.getDefaultSharedPreferences(todoApplication));
+	}
+
+	@Override
+	public RemoteClient getRemoteClient() {
+		return remoteClient;
+	}
+	
+	public class RemoteClientStub implements RemoteClient {
+
+		@Override
+		public Client getClient() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public boolean authenticate() {
+			// TODO Auto-generated method stub
+			return true;
+		}
+
+		@Override
+		public boolean startLogin() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public boolean finishLogin() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public void deauthenticate() {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public boolean isAuthenticated() {
+			// TODO Auto-generated method stub
+			return true;
+		}
+
+		@Override
+		public boolean isLoggedIn() {
+			// TODO Auto-generated method stub
+			return true;
+		}
+
+		@Override
+		public PullTodoResult pullTodo() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public void pushTodo(File todoFile, File doneFile, boolean overwrite) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public boolean isAvailable() {
+			// TODO Auto-generated method stub
+			return true;
+		}
+	}
+}

--- a/tests/src/com/todotxt/todotxttouch/test/TaskBagStub.java
+++ b/tests/src/com/todotxt/todotxttouch/test/TaskBagStub.java
@@ -1,0 +1,107 @@
+package com.todotxt.todotxttouch.test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import com.todotxt.todotxttouch.task.Filter;
+import com.todotxt.todotxttouch.task.Priority;
+import com.todotxt.todotxttouch.task.Task;
+import com.todotxt.todotxttouch.task.TaskBag;
+
+public class TaskBagStub implements TaskBag {
+
+	@Override
+	public void archive() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void reload() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void addAsTask(String input) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void update(Task task) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void delete(Task task) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public List<Task> getTasks() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<Task> getTasks(Filter<Task> filter, Comparator<Task> comparator) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public int size() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public ArrayList<String> getProjects() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public ArrayList<String> getContexts() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public ArrayList<Priority> getPriorities() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void pushToRemote(boolean overwrite) {
+		// TODO Auto-generated method stub
+		pushToRemote(false, overwrite);
+	}
+
+	@Override
+	public void pushToRemote(boolean overridePreference, boolean overwrite) {
+		// TODO Auto-generated method stub
+		++pushToRemoteCalled;
+
+	}
+	public int pushToRemoteCalled = 0;
+
+	@Override
+	public void pullFromRemote() {
+		// TODO Auto-generated method stub
+		pullFromRemote(false);
+	}
+
+	@Override
+	public void pullFromRemote(boolean overridePreference) {
+		// TODO Auto-generated method stub
+		++pullFromRemoteCalled;
+	}
+	public int pullFromRemoteCalled = 0;
+
+}

--- a/tests/src/com/todotxt/todotxttouch/test/TodoApplicationTest.java
+++ b/tests/src/com/todotxt/todotxttouch/test/TodoApplicationTest.java
@@ -1,0 +1,260 @@
+package com.todotxt.todotxttouch.test;
+
+import java.lang.reflect.Field;
+
+import com.todotxt.todotxttouch.Constants;
+import com.todotxt.todotxttouch.TodoApplication;
+import com.todotxt.todotxttouch.remote.RemoteClientManager;
+import com.todotxt.todotxttouch.task.TaskBag;
+
+import android.content.Intent;
+import android.test.ApplicationTestCase;
+
+public class TodoApplicationTest extends ApplicationTestCase<TodoApplication> {
+
+	public TodoApplicationTest() {
+		super(TodoApplication.class);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		createApplication();
+		TodoApplication app = getApplication();
+
+		RemoteClientManager mgr = new RemoteClientManagerStub(app);
+		try {
+			Field mgrField = TodoApplication.class
+					.getDeclaredField("remoteClientManager");
+			mgrField.setAccessible(true);
+			mgrField.set(app, mgr);
+		} catch (Exception e) {
+			fail(e.toString());
+		}
+
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+	}
+
+	private void setTaskBag(TaskBag bag) {
+		TodoApplication app = getApplication();
+
+		try {
+			Field bagField = TodoApplication.class.getDeclaredField("taskBag");
+			bagField.setAccessible(true);
+			bagField.set(app, bag);
+		} catch (Exception e) {
+			fail(e.toString());
+		}
+	}
+
+	public class Waiter {
+		private static final long sleepInterval = 60;
+		private static final long maxWait = 5000;
+
+		public boolean doWait() {
+			long elapsed = 0;
+			boolean res = false;
+			while (!(res = test()) && elapsed < maxWait) {
+				try {
+					Thread.sleep(sleepInterval);
+				} catch (InterruptedException e) {
+				}
+				elapsed += sleepInterval;
+			}
+			return res;
+		}
+
+		public boolean test() {
+			return false;
+		}
+	}
+
+	public void testPushToRemote() {
+		final TaskBagStub bag = new TaskBagStub();
+		setTaskBag(bag);
+
+		TodoApplication app = getApplication();
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 1;
+			};
+		}.doWait();
+
+		assertEquals("Should have called pushToRemote once", 1,
+				bag.pushToRemoteCalled);
+		// Remember that pull is called automatically after a successful push
+		assertEquals("Should have called pullToRemote once", 1,
+				bag.pullFromRemoteCalled);
+	}
+
+	public void testPushToRemoteMultiple() {
+		final TaskBagStub bag = new TaskBagStub();
+		setTaskBag(bag);
+
+		TodoApplication app = getApplication();
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 1;
+			};
+		}.doWait();
+
+		assertEquals("Should have called pushToRemote twice", 2,
+				bag.pushToRemoteCalled);
+		// Remember that pull is called automatically after a successful push
+		assertEquals("Should have called pullToRemote twice", 1,
+				bag.pullFromRemoteCalled);
+	}
+
+	public void testPushToRemoteMultipleDelayed() {
+		final TaskBagStub bag = new TaskBagStub() {
+			@Override
+			public void pushToRemote(boolean overridePreference,
+					boolean overwrite) {
+				super.pushToRemote(overridePreference, overwrite);
+				if (pushToRemoteCalled <= 1) {
+					try {
+						Thread.sleep(200);
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+		};
+		setTaskBag(bag);
+
+		TodoApplication app = getApplication();
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pushToRemoteCalled == 1;
+			};
+		}.doWait();
+
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 1;
+			};
+		}.doWait();
+
+		assertEquals("Should have called pushToRemote twice", 2,
+				bag.pushToRemoteCalled);
+		// Remember that pull is called automatically after a successful push
+		assertEquals("Should have called pullToRemote once", 1,
+				bag.pullFromRemoteCalled);
+	}
+
+	public void testPushToRemoteMultipleDelayedWithPull() {
+		final TaskBagStub bag = new TaskBagStub() {
+			@Override
+			public void pushToRemote(boolean overridePreference,
+					boolean overwrite) {
+				super.pushToRemote(overridePreference, overwrite);
+				if (pushToRemoteCalled <= 1) {
+					try {
+						Thread.sleep(200);
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+		};
+		setTaskBag(bag);
+
+		TodoApplication app = getApplication();
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pushToRemoteCalled == 1;
+			};
+		}.doWait();
+
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		// This pull should not be called
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_FROM_REMOTE));
+
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 1;
+			};
+		}.doWait();
+
+		assertEquals("Should have called pushToRemote twice", 2,
+				bag.pushToRemoteCalled);
+		// Remember that pull is called automatically after a successful push
+		assertEquals("Should have called pullToRemote once", 1,
+				bag.pullFromRemoteCalled);
+	}
+
+	public void testPushToRemoteMultipleDelayedThenPull() {
+		final TaskBagStub bag = new TaskBagStub() {
+			@Override
+			public void pushToRemote(boolean overridePreference,
+					boolean overwrite) {
+				super.pushToRemote(overridePreference, overwrite);
+				if (pushToRemoteCalled <= 1) {
+					try {
+						Thread.sleep(200);
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+		};
+		setTaskBag(bag);
+
+		TodoApplication app = getApplication();
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pushToRemoteCalled == 1;
+			};
+		}.doWait();
+
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 1;
+			};
+		}.doWait();
+
+		// This pull should be called
+		app.sendBroadcast(new Intent(Constants.INTENT_START_SYNC_FROM_REMOTE));
+
+		new Waiter() {
+			public boolean test() {
+				return bag.pullFromRemoteCalled == 2;
+			};
+		}.doWait();
+
+		assertEquals("Should have called pushToRemote twice", 2,
+				bag.pushToRemoteCalled);
+		// Remember that pull is called automatically after a successful push
+		assertEquals("Should have called pullToRemote twice", 2,
+				bag.pullFromRemoteCalled);
+	}
+
+}


### PR DESCRIPTION
Each call to push will increment a counter of pending push operations,
then launch a remote push in the background if one is not already running.
The background operation will clear the counter before starting.
After it completes, it will check the counter and relaunch itself if needed.
This will prevent race conditions that occur when multiple push operations
are in progress at the same time.

Push and pull operations will still not occur simultaneously, as always.

Fixes #272
