### PR TITLE
Update widget when pull and push is complete, regardless of result.

### DIFF
--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -293,9 +293,6 @@ public class AddTask extends Activity {
 					} else {
 						taskBag.addAsTask(input);
 					}
-
-					// make widgets update
-					m_app.broadcastWidgetUpdate();
 					return true;
 				} catch (Exception e) {
 					Log.e(TAG, "input: " + input + " - " + e.getMessage());

--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -124,6 +124,8 @@ public class TodoApplication extends Application {
 			Log.i(TAG, "Not connected, don't push now");
 			showToast(R.string.toast_notconnected);
 		}
+
+        broadcastWidgetUpdate();
 	}
 
 	/**
@@ -147,6 +149,8 @@ public class TodoApplication extends Application {
 			Log.i(TAG, "Not connected, don't pull now");
 			showToast(R.string.toast_notconnected);
 		}
+
+        broadcastWidgetUpdate();
 	}
 
 	public TaskBag getTaskBag() {

--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -435,7 +435,6 @@ public class TodoTxtTouch extends ListActivity implements
 							task.setPriority(Priority
 									.toPriority(prioArr[which]));
 							taskBag.update(task);
-							m_app.broadcastWidgetUpdate();
 							return true;
 						} catch (Exception e) {
 							Log.e(TAG, e.getMessage(), e);
@@ -579,7 +578,6 @@ public class TodoTxtTouch extends ListActivity implements
 					protected Boolean doInBackground(Object... params) {
 						try {
 							taskBag.delete((Task) params[0]);
-							m_app.broadcastWidgetUpdate();
 							return true;
 						} catch (Exception e) {
 							Log.e(TAG, e.getMessage(), e);


### PR DESCRIPTION
Removed broadcasts on add, update and delete task.

Added broadcast to pull and push, happens regardless of result from remote.

Fixes #321
