### PR TITLE
Give focus to text input in AddTask activity

### DIFF
--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -138,6 +138,8 @@ public class AddTask extends Activity {
 		textInputField.setSelection(textInputField.getText().toString()
 				.length());
 		
+		textInputField.requestFocus();
+		
 		// priorities
 		priorities = (Spinner) findViewById(R.id.priorities);
 		final ArrayList<String> prioArr = new ArrayList<String>();


### PR DESCRIPTION
When you add a new task on a device with a hardware keyboard (or connected Bluetooth keyboard), the focus goes not to the text edit field, but to the Priority button in the upper-left.

With this change, it works fine!

Fixes #324.
