### PR TITLE
Sync when making tasks changes through CAB

### DIFF
--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -344,7 +344,10 @@ public class TodoTxtTouch extends SherlockListActivity implements
 					protected void onPostExecute(Boolean result) {
 						TodoTxtTouch.currentActivityPointer
 								.dismissProgressDialog(true);
-						if (!result) {
+						if (result) {
+							sendBroadcast(new Intent(
+									Constants.INTENT_START_SYNC_TO_REMOTE));
+						} else {
 							Util.showToastLong(TodoTxtTouch.this,
 									"Could not prioritize tasks");
 						}
@@ -383,7 +386,10 @@ public class TodoTxtTouch extends SherlockListActivity implements
 					protected void onPostExecute(Boolean result) {
 						TodoTxtTouch.currentActivityPointer
 								.dismissProgressDialog(true);
-						if (!result) {
+						if (result) {
+							sendBroadcast(new Intent(
+									Constants.INTENT_START_SYNC_TO_REMOTE));
+						} else {
 							Util.showToastLong(TodoTxtTouch.this,
 									"Could not mark tasks as not completed");
 						}
@@ -425,7 +431,10 @@ public class TodoTxtTouch extends SherlockListActivity implements
 
 			protected void onPostExecute(Boolean result) {
 				TodoTxtTouch.currentActivityPointer.dismissProgressDialog(true);
-				if (!result) {
+				if (result) {
+					sendBroadcast(new Intent(
+							Constants.INTENT_START_SYNC_TO_REMOTE));
+				} else {
 					Util.showToastLong(TodoTxtTouch.this,
 							"Could not complete tasks");
 				}
@@ -468,7 +477,10 @@ public class TodoTxtTouch extends SherlockListActivity implements
 					protected void onPostExecute(Boolean result) {
 						TodoTxtTouch.currentActivityPointer
 								.dismissProgressDialog(true);
-						if (!result) {
+						if (result) {
+							sendBroadcast(new Intent(
+									Constants.INTENT_START_SYNC_TO_REMOTE));
+						} else {
 							Util.showToastLong(TodoTxtTouch.this,
 									"Could not delete tasks ");
 						}


### PR DESCRIPTION
Was caused by overenthusiastic removal of success case when changing tasks.
