### PR TITLE
Make widget resizeable

### DIFF
--- a/res/xml/todo_widget_provider.xml
+++ b/res/xml/todo_widget_provider.xml
@@ -27,4 +27,5 @@ You should have received a copy of the GNU General Public License along with Tod
 	android:minWidth="294dp"
 	android:minHeight="40dp"
 	android:initialLayout="@layout/widget"
+	android:resizeMode="horizontal|vertical"
 	android:updatePeriodMillis="1000" />


### PR DESCRIPTION
This makes the widget resizeable on 4.2.2. I haven't tested other versions.

Fixes #275.
