### PR TITLE
Make widget resizeable

### DIFF
--- a/res/xml/todo_widget_provider.xml
+++ b/res/xml/todo_widget_provider.xml
@@ -27,4 +27,5 @@ You should have received a copy of the GNU General Public License along with Tod
 	android:minWidth="294dp"
 	android:minHeight="40dp"
 	android:initialLayout="@layout/widget"
+	android:resizeMode="horizontal|vertical"
 	android:updatePeriodMillis="1000" />

--- a/src/com/todotxt/todotxttouch/TodoWidgetProvider.java
+++ b/src/com/todotxt/todotxttouch/TodoWidgetProvider.java
@@ -43,7 +43,7 @@ import com.todotxt.todotxttouch.task.TaskBag;
 public class TodoWidgetProvider extends AppWidgetProvider {
 
 	private static final String TAG = TodoWidgetProvider.class.getName();
-	private static final int TASKS_TO_DISPLAY = 3;
+	private static final int TASKS_TO_DISPLAY = 15;
 
 	private static final int TASK_ID = 0;
 	private static final int TASK_PRIO = 1;


### PR DESCRIPTION
This makes the widget resizeable on 4.2.2, with a maximum of 15 displayed tasks.
I haven't tested other versions.

Fixes #275.
