### PR TITLE
Add periodic background sync

### DIFF
--- a/AndroidManifest.sample.xml
+++ b/AndroidManifest.sample.xml
@@ -39,8 +39,8 @@ You should have received a copy of the GNU General Public License along with Tod
         android:resizeable="true"
         android:smallScreens="true" />
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" >
-    </uses-permission>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
         android:name=".TodoApplication"
@@ -149,7 +149,14 @@ You should have received a copy of the GNU General Public License along with Tod
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/todo_widget_provider" />
+        </receiver> 
+        <receiver android:name=".PeriodicSyncStarter" >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
         </receiver>
+        
+        <service android:name=".SyncerService"/>
     </application>
 
 </manifest>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -30,5 +30,21 @@ You should have received a copy of the GNU General Public License along with Tod
 		<item>Line descending</item>
 		<item>Text (A-Z)</item>
 	</string-array>
+	
+	<string-array name="periodic_sync_lengths">
+	    <item>Disabled</item>
+		<item>15 minutes</item>
+		<item>1 hour</item>
+		<item>12 hours</item>
+		<item>1 day</item>
+	</string-array>
+	
+	<string-array name="periodic_sync_values"> <!-- values from AlarmManager.INTERVAL_* -->
+		<item>0</item>
+		<item>900000</item>
+		<item>3600000</item>
+		<item>43200000</item>
+		<item>86400000</item>
+	</string-array>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -95,6 +95,8 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="manual_sync_pref_key">workofflinepref</string>
     <string name="manual_sync_pref_title">Manual sync</string>
     <string name="manual_sync_pref_summary">Don\'t automatically upload every change to Dropbox.</string>
+    <string name="periodic_sync_pref_key">sync_period</string>
+    <string name="periodic_sync_pref_title">Sync every</string>
 
 
     <!-- sync dialog -->

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -52,6 +52,9 @@
 			android:key="@string/TODOTXTPATH_key" />
 		<CheckBoxPreference android:key="@string/manual_sync_pref_key"
 			android:title="@string/manual_sync_pref_title" android:summary="@string/manual_sync_pref_summary" />
+		<ListPreference android:key="@string/periodic_sync_pref_key"
+		    android:title="@string/periodic_sync_pref_title" android:entries="@array/periodic_sync_lengths"
+		    android:entryValues="@array/periodic_sync_values" android:defaultValue="0" />
 		<Preference android:key="logout_dropbox" android:title="@string/dropbox_logout_pref_title"
 			android:summary="@string/dropbox_logout_pref_summary" />
 	</PreferenceCategory>

--- a/src/com/todotxt/todotxttouch/Constants.java
+++ b/src/com/todotxt/todotxttouch/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
 	public static final String PREF_DONE_REV = "done_rev";
 	public static final String PREF_MANUAL_MODE = "workofflinepref";
 	public static final String PREF_NEED_TO_PUSH = "need_to_push";
+	public static final String PREF_PERIODIC_SYNC = "sync_period";
 	public static final String DROPBOX_MODUS = "dropbox";
 
 	public final static long INVALID_ID = -1;
@@ -47,6 +48,7 @@ public class Constants {
 	public final static String EXTRA_APPLIED_FILTERS = "APPLIED_FITERS";
 	public final static String EXTRA_FORCE_SYNC = "FORCE_SYNC";
 	public final static String EXTRA_OVERWRITE = "OVERWRITE";
+	public static final String EXTRA_SUPPRESS_TOAST = "SUPPRESS_TOAST";
 
 	public final static String INTENT_ACTION_ARCHIVE = "com.todotxt.todotxttouch.ACTION_ARCHIVE";
 	public final static String INTENT_ACTION_LOGOUT = "com.todotxt.todotxttouch.ACTION_LOGOUT";

--- a/src/com/todotxt/todotxttouch/PeriodicSyncStarter.java
+++ b/src/com/todotxt/todotxttouch/PeriodicSyncStarter.java
@@ -1,0 +1,34 @@
+package com.todotxt.todotxttouch;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class PeriodicSyncStarter extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED")) {
+            setupPeriodicSyncer(context);
+        }
+    }
+
+    public static void setupPeriodicSyncer(Context context) {
+
+        TodoApplication a = (TodoApplication) context.getApplicationContext();
+        AlarmManager alarms = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        Intent i = new Intent(context, SyncerService.class);
+        PendingIntent pi = PendingIntent.getService(context, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
+        alarms.cancel(pi); // Cancel any previously started
+        long syncPeriod = a.getSyncPeriod();
+        if (syncPeriod > 0) {
+            // Wake up and synchronise after after inexact fixed delay
+            alarms.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, 0, syncPeriod, pi);
+//            alarms.setRepeating(AlarmManager.ELAPSED_REALTIME, 0, 60 * 1000, pi); // for testing
+        }
+    }
+
+}

--- a/src/com/todotxt/todotxttouch/SyncerService.java
+++ b/src/com/todotxt/todotxttouch/SyncerService.java
@@ -1,0 +1,41 @@
+package com.todotxt.todotxttouch;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Message;
+
+
+/**
+ * Hoster service for the periodic sync service. We need this to spin up the TodoApplication object.
+ */
+public class SyncerService extends Service {
+    
+    private static final long KEEP_ALIVE = 30 * 1000L;
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+
+        Intent i = new Intent(Constants.INTENT_START_SYNC_WITH_REMOTE);
+        i.putExtra(Constants.EXTRA_SUPPRESS_TOAST, true);
+        sendBroadcast(i);
+        // Shut down after a short delay. This is slightly strange, but we have no way of knowing when
+        // the sync has finished so in most cases this will be long enough.
+        new Handler(new Handler.Callback() {
+            
+            @Override
+            public boolean handleMessage(Message msg) {
+                stopSelf();
+                return true;
+            }
+        }).sendEmptyMessageDelayed(0, KEEP_ALIVE); 
+        return Service.START_NOT_STICKY; // If it crashes, don't restart
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+}

--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -96,20 +96,20 @@ public class TodoApplication extends Application {
 	 * If we previously tried to push and failed, then attempt to push again
 	 * now. Otherwise, pull.
 	 */
-	private void syncWithRemote(boolean force) {
+	private void syncWithRemote(boolean force, boolean suppressToast) {
 		if (needToPush()) {
 			Log.d(TAG, "needToPush = true; pushing.");
-			pushToRemote(force, false);
+			pushToRemote(force, false, suppressToast);
 		} else {
 			Log.d(TAG, "needToPush = false; pulling.");
-			pullFromRemote(force);
+			pullFromRemote(force, suppressToast);
 		}
 	}
 
 	/**
 	 * Check network status, then push.
 	 */
-	private void pushToRemote(boolean force, boolean overwrite) {
+	private void pushToRemote(boolean force, boolean overwrite, boolean suppressToast) {
 		pushQueue += 1;
 		setNeedToPush(true);
 		if (!force && isManualMode()) {
@@ -117,19 +117,21 @@ public class TodoApplication extends Application {
 		} else if (getRemoteClientManager().getRemoteClient().isAvailable()
 				&& !m_pulling) {
 			Log.i(TAG, "Working online; should push if file revisions match");
-			backgroundPushToRemote(overwrite);
+			backgroundPushToRemote(overwrite, suppressToast);
 		} else if (m_pulling) {
 			Log.d(TAG, "app is pulling right now. don't start push."); 
 		} else {
 			Log.i(TAG, "Not connected, don't push now");
-			showToast(R.string.toast_notconnected);
+			if (!suppressToast) {
+			    showToast(R.string.toast_notconnected);
+			}
 		}
 	}
 
 	/**
 	 * Check network status, then pull.
 	 */
-	private void pullFromRemote(boolean force) {
+	private void pullFromRemote(boolean force, boolean suppressToast) {
 		if (!force && isManualMode()) {
 			Log.i(TAG, "Working offline, don't pull now");
 			return;
@@ -145,7 +147,10 @@ public class TodoApplication extends Application {
 			Log.d(TAG, "app is pushing right now. don't start pull."); 
 		} else {
 			Log.i(TAG, "Not connected, don't pull now");
-			showToast(R.string.toast_notconnected);
+			
+			if (!suppressToast) {
+			    showToast(R.string.toast_notconnected);
+			}
 		}
 	}
 
@@ -186,10 +191,10 @@ public class TodoApplication extends Application {
 	/**
 	 * Do asynchronous push with gui changes. Do availability check first.
 	 */
-	void backgroundPushToRemote(final boolean overwrite) {
+	void backgroundPushToRemote(final boolean overwrite, final boolean suppressToast) {
 		if (getRemoteClientManager().getRemoteClient().isAuthenticated()) {
 			if(!(m_pushing || m_pulling)) {
-				new AsyncPushTask(overwrite).execute();
+				new AsyncPushTask(overwrite, suppressToast).execute();
 			}
 		} else {
 			Log.e(TAG, "NOT AUTHENTICATED!");
@@ -202,10 +207,12 @@ public class TodoApplication extends Application {
 		static final int CONFLICT = 1;
 		static final int ERROR = 2;
 
-		private boolean overwrite = false;
+		private boolean overwrite;
+        private boolean suppressToast;
 		
-		public AsyncPushTask(boolean overwrite) {
+		public AsyncPushTask(boolean overwrite, boolean suppressToast) {
 			this.overwrite = overwrite;
+			this.suppressToast = suppressToast;
 		}
 		
 		@Override
@@ -238,14 +245,14 @@ public class TodoApplication extends Application {
 				if (pushQueue > 0) {
 					m_pushing = true;
 					Log.d(TAG, "pushQueue == " + pushQueue + ". Need to push again.");
-					new AsyncPushTask(false).execute();
+					new AsyncPushTask(false, suppressToast).execute();
 				} else {
 					Log.d(TAG, "taskBag.pushToRemote done");
 					setNeedToPush(false);
 					updateSyncUI(false);
 					// Push is complete. Now do a pull in case the remote
 					// done.txt has changed.
-					pullFromRemote(true);
+					pullFromRemote(true, suppressToast);
 				}
 			} else if (result == CONFLICT) {
 				// FIXME: need to know which file had conflict
@@ -312,18 +319,22 @@ public class TodoApplication extends Application {
 					Constants.EXTRA_FORCE_SYNC, false);
 			boolean overwrite = intent.getBooleanExtra(
 					Constants.EXTRA_OVERWRITE, false);
+			boolean suppressToast = intent.getBooleanExtra(
+                    Constants.EXTRA_SUPPRESS_TOAST, false);
 			if (intent.getAction().equalsIgnoreCase(
 					Constants.INTENT_START_SYNC_WITH_REMOTE)) {
-				syncWithRemote(force_sync);
+				syncWithRemote(force_sync, suppressToast);
 			} else if (intent.getAction().equalsIgnoreCase(
 					Constants.INTENT_START_SYNC_TO_REMOTE)) {
-				pushToRemote(force_sync, overwrite);
+				pushToRemote(force_sync, overwrite, suppressToast);
 			} else if (intent.getAction().equalsIgnoreCase(
 					Constants.INTENT_START_SYNC_FROM_REMOTE)) {
-				pullFromRemote(force_sync);
+				pullFromRemote(force_sync, suppressToast);
 			} else if (intent.getAction().equalsIgnoreCase(
 					Constants.INTENT_ASYNC_FAILED)) {
-				showToast("Synchronizing Failed");
+			    if (!suppressToast) {
+			        showToast("Synchronizing Failed");
+			    }
 				m_pulling = false;
 				m_pushing = false;
 				updateSyncUI(true);
@@ -336,5 +347,14 @@ public class TodoApplication extends Application {
 		Intent intent = new Intent(Constants.INTENT_WIDGET_UPDATE);
 		sendBroadcast(intent);
 	}
+
+    public long getSyncPeriod() {
+        try {
+            long period = Long.parseLong(m_prefs.getString(Constants.PREF_PERIODIC_SYNC, "0"));
+            return period;
+        } catch (NumberFormatException ex) {
+            return 0L;
+        }
+    }
 
 }


### PR DESCRIPTION
Adds a periodic background sync. Service to host the app, new preference. Suppresses error toasts when sync originates from periodic alarm.

To start this properly on boot we need a new permission.
