### PR TITLE
Removed need for sample manifest file.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,13 +4,14 @@
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry kind="lib" path="libs/apache-mime4j-0.6.jar"/>
-	<classpathentry kind="lib" path="libs/httpmime-4.0.3.jar"/>
-	<classpathentry kind="lib" path="libs/json_simple-1.1.jar"/>
-	<classpathentry kind="lib" path="libs/libphonenumber-4.1.jar"/>
-	<classpathentry kind="lib" path="libs/signpost-commonshttp4-1.2.1.1.jar"/>
-	<classpathentry kind="lib" path="libs/signpost-core-1.2.1.1.jar"/>
-	<classpathentry kind="lib" path="dependencies/JakeWharton-ActionBarSherlock-c47975f/actionbarsherlock/libs/android-support-v4.jar"/>
-	<classpathentry kind="lib" path="libs/dropbox-android-sdk-1.5.4.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/apache-mime4j-0.6.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/httpmime-4.0.3.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/json_simple-1.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/libphonenumber-4.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/signpost-commonshttp4-1.2.1.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/signpost-core-1.2.1.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="dependencies/JakeWharton-ActionBarSherlock-c47975f/actionbarsherlock/libs/android-support-v4.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/dropbox-android-sdk-1.5.4.jar"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ bin/
 gen/
 res/values/dropbox.xml
 proguard.cfg
-/AndroidManifest.xml

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -52,17 +52,8 @@ You should have received a copy of the GNU General Public License along with Tod
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask" >
             <intent-filter>
-
-                <!-- For Android 1.6 compatibility, we cannot reference a string resource here 
-                On 1.6, when auth'ing to Dropbox, it throws a 
-                java.lang.IllegalStateException: URL scheme in your app's manifest is not set up correctly.
                 <data android:scheme="@string/dropbox_consumer_key" />
-                -->
-				<!-- Change this to be db- followed by your Dropbox app key -->
-				 <data android:scheme="db-PUT-APP-KEY-HERE" />
-
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/res/values/sample-dropbox.xml
+++ b/res/values/sample-dropbox.xml
@@ -25,7 +25,8 @@ You should have received a copy of the GNU General Public License along with Tod
 <resources>
 <!--
 First, copy this file to dropbox.xml. Then uncomment out the following lines and fill in the appropriate values.
-    <string name="dropbox_consumer_key">Enter your Dropbox app key here</string>
+The dropbox_consumer_key value must start with 'db-'
+    <string name="dropbox_consumer_key">db-Enter your Dropbox app key here</string>
     <string name="dropbox_consumer_secret">Enter your Dropbox app secret here</string>
 -->    
 </resources>

--- a/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
+++ b/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
@@ -115,6 +115,7 @@ class DropboxRemoteClient implements RemoteClient {
 	public boolean authenticate() {
 		String consumerKey = todoApplication.getResources()
 				.getText(R.string.dropbox_consumer_key).toString();
+		consumerKey = consumerKey.replaceFirst("^db-", "");
 		String consumerSecret = todoApplication.getText(
 				R.string.dropbox_consumer_secret).toString();
 


### PR DESCRIPTION
Since we are building to a minimum API version of 7 now, we can now use string references in the Android manifest file.
Your dropbox.xml file will have to be modified to add the 'db-' to the beginning of the consumer key.
Fixes #343 
