### PR TITLE
Use sp rather than dip in TextViews to respect user's system text size settings. #186

### DIFF
--- a/res/layout/list_item.xml
+++ b/res/layout/list_item.xml
@@ -27,16 +27,16 @@ You should have received a copy of the GNU General Public License along with Tod
 
 	<TextView android:id="@+id/taskprio" android:layout_width="wrap_content"
 		android:layout_height="wrap_content" android:padding="4dip"
-		android:textSize="16dip" android:textStyle="bold" />
+		android:textSize="16sp" android:textStyle="bold" />
 
 	<TextView android:id="@+id/tasktext" android:layout_width="wrap_content"
 		android:layout_height="wrap_content" android:paddingLeft="4dip"
 		android:paddingRight="4dip" android:paddingTop="4dip"
-		android:textSize="16dip" android:layout_toRightOf="@id/taskprio" />
+		android:textSize="16sp" android:layout_toRightOf="@id/taskprio" />
 
 	<TextView android:id="@+id/taskage" android:layout_width="wrap_content"
 		android:layout_height="wrap_content" android:paddingLeft="4dip"
-		android:paddingBottom="4dip" android:textSize="11dip"
+		android:paddingBottom="4dip" android:textSize="11sp"
 		android:layout_below="@id/tasktext" android:layout_toRightOf="@id/taskprio"
 		android:textColor="@color/grey" android:visibility="gone" />
 


### PR DESCRIPTION
#186 was already mainly fixed. Text size doesn't need to be an option in the app. The app should just respect the user's system text size settings by using sp rather than dip for TextViews.

This is the only place I could find in the app that used dip from than sp.
