### PR TITLE
Update .gitignore to ignore Android Studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ gen/
 res/values/dropbox.xml
 proguard.cfg
 /AndroidManifest.xml
+
+# IntelliJ Idea/Android Studio files
+*.iml
+*.ipr
+*.iws
+.idea/


### PR DESCRIPTION
I've been using the new Android Studio with the todo.txt app sourcecode (it works perfectly). This pull request just adds the extra files which shouldn't be checked in to .gitignore.
