### PR TITLE
Add support for google voice "Note to Self"

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -105,10 +105,10 @@ You should have received a copy of the GNU General Public License along with Tod
             android:targetActivity=".AddTask" >
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-
+				<action android:name="com.google.android.gm.action.AUTO_SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
 
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/*" />
             </intent-filter>
         </activity-alias>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -65,7 +65,8 @@ You should have received a copy of the GNU General Public License along with Tod
 	<string name="addcontextproject">Add @context or +project</string>
 	<string name="assignpriority">Prioritize this task</string>
 	<string name="filterbycontextproject">Filter by @context or +project</string>
-
+	<string name="taskadded">Task added</string>
+	
     <!-- settings -->
     <string name="ARCHIVE_settings_header">done.txt</string>
     <string name="auto_archive_pref_key">todotxtautoarchive</string>

--- a/src/com/todotxt/todotxttouch/AddTask.java
+++ b/src/com/todotxt/todotxttouch/AddTask.java
@@ -69,6 +69,15 @@ public class AddTask extends SherlockActivity {
 		getSupportMenuInflater().inflate(R.menu.add_task, menu);
 		return true;
 	}
+	
+	private void noteToSelf (Intent intent) {
+		String task = intent.getStringExtra(Intent.EXTRA_TEXT);
+        taskBag.addAsTask(task);
+        m_app.setNeedToPush(true);
+        sendBroadcast(new Intent(Constants.INTENT_START_SYNC_TO_REMOTE));
+        m_app.showToast(R.string.taskadded);
+    }
+
 
 	@Override
 	public boolean onMenuItemSelected(int featureId, MenuItem item) {
@@ -98,6 +107,8 @@ public class AddTask extends SherlockActivity {
 
 		m_app = (TodoApplication) getApplication();
 		taskBag = m_app.getTaskBag();
+		
+		
 
 		sendBroadcast(new Intent(Constants.INTENT_START_SYNC_WITH_REMOTE));
 
@@ -114,8 +125,12 @@ public class AddTask extends SherlockActivity {
 			share_text = (String) intent
 					.getCharSequenceExtra(Intent.EXTRA_TEXT);
 			Log.d(TAG, share_text);
+		} else if ("com.google.android.gm.action.AUTO_SEND".equals(action)) {
+	        // Called as note to self from google search/now
+	        noteToSelf(intent);
+	        finish();
+	        return;
 		}
-
 		// text
 		textInputField = (EditText) findViewById(R.id.taskText);
 		textInputField.setGravity(Gravity.TOP);


### PR DESCRIPTION
One of the things that would really help in easily adding task from your phone is to support the "note to self" google voice intent.
This commit will add todo.txt as a receiver for the note to self intent. This allows you to click google voice search, say "note buy milk" and it will be added to your todo list.
