### PR TITLE
Remove outdated configchanges from AndroidManifest.xml

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -62,7 +62,6 @@ You should have received a copy of the GNU General Public License along with Tod
         </activity>
         <activity
             android:name=".LoginScreen"
-            android:configChanges="keyboardHidden|orientation"
             android:label="@string/app_label"
             android:theme="@android:style/Theme.NoTitleBar" >
             <intent-filter>
@@ -80,7 +79,6 @@ You should have received a copy of the GNU General Public License along with Tod
             android:label="@string/set_preferences" />
         <activity
             android:name=".AddTask"
-            android:configChanges="orientation|keyboardHidden"
             android:label="@string/addtask"
             android:windowSoftInputMode="adjustResize" >
             <intent-filter>
@@ -115,8 +113,7 @@ You should have received a copy of the GNU General Public License along with Tod
             android:name=".HelpActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
         <activity
-            android:name=".TodoTxtTouch"
-            android:configChanges="keyboardHidden|orientation" >
+            android:name=".TodoTxtTouch">
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
             </intent-filter>


### PR DESCRIPTION
Setting configchanges should only be used as a last resort to stop activities restarting on rotation. Especially now that ActionBarSherlock has been integrated which is known not to always work correctly with configchanges (and will probably never be fixed: https://github.com/JakeWharton/ActionBarSherlock/issues/279#issuecomment-7744399)

I've left the com.dropbox.client2.android.AuthActivity one in because that is still in the Dropbox developer instructions and removing it did cause the Dropbox sign in page to reload on rotation which may cause problems.

However, I haven't noticed any other problems in the other activities and, if there are any, then they should be fixed properly.

Another reason for this change is that "keyboardHidden|orientation" hasn't actually been enough since Android 3.2 when "screenSize|smallestScreenSize" was also required to avoid restarting the activities.
