### PR TITLE
Fix for crash after filter.

### DIFF
--- a/dependencies/chuckbjones-SwipeToDismissUndoList-ec6bf93/src/de/timroes/swipetodismiss/SwipeDismissList.java
+++ b/dependencies/chuckbjones-SwipeToDismissUndoList-ec6bf93/src/de/timroes/swipetodismiss/SwipeDismissList.java
@@ -432,7 +432,8 @@ public final class SwipeDismissList implements View.OnTouchListener {
 				if (mPaused || !mEnabled) {
 					return false;
 				}
-
+				resetSwipeState();
+				
 				// TODO: ensure this is a finger, and set a flag
 
 				// Find the child view that was touched (perform a hit test)
@@ -516,13 +517,7 @@ public final class SwipeDismissList implements View.OnTouchListener {
 						.setDuration(mAnimationTime)
 						.setListener(null);
 				}
-				mVelocityTracker.recycle();
-				mVelocityTracker = null;
-				mDownX = 0;
-				mDownY = 0;
-				mDownView = null;
-				mDownPosition = ListView.INVALID_POSITION;
-				mSwiping = false;
+				resetSwipeState();
 				break;
 			}
 
@@ -572,6 +567,18 @@ public final class SwipeDismissList implements View.OnTouchListener {
 			}
 		}
 		return false;
+	}
+
+	private void resetSwipeState() {
+		if (mVelocityTracker != null) {
+			mVelocityTracker.recycle();
+		}
+		mVelocityTracker = null;
+		mDownX = 0;
+		mDownY = 0;
+		mDownView = null;
+		mDownPosition = ListView.INVALID_POSITION;
+		mSwiping = false;
 	}
 
 	/**


### PR DESCRIPTION
SwipeDismissList was crashing after getting a touch down event immediately after filtering. It only happened when the list had been scrolled to the bottom before filtering and the the filtered list is too short to fill the screen. I'm not entirely sure why it was happening, but it looks like SwipeDismissList was not getting an UP touch event, so it was not resetting its state. When it later got the DOWN event, it tried to reuse a no longer existent view, and crashed.

I fixed it by resetting the state at the beginning of the DOWN event handler as well as at the end of the UP handler.
