### PR TITLE
Added highlighting to selected filters in navigation drawer and tweaked styling

### DIFF
--- a/res/layout/drawer_list_item.xml
+++ b/res/layout/drawer_list_item.xml
@@ -13,14 +13,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/text1"
+<com.todotxt.todotxttouch.RelativeLayoutCheckable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+<TextView 
+    android:id="@+id/left_drawer_text"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:gravity="center_vertical"
     android:paddingLeft="16dip"
     android:paddingRight="16dip"
-    android:textColor="#fff"
-    android:minHeight="48dp"/>
+    android:minHeight="48dp"
+    style="@style/TodoTxtTouchLight"
+            />
+</com.todotxt.todotxttouch.RelativeLayoutCheckable>

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -112,7 +112,6 @@ You should have received a copy of the GNU General Public License along with Tod
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:choiceMode="singleChoice"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="0dip"
-            android:background="#111"/>
+            style="@style/TodoTxtTouchLight"
+            android:background="#f3f3f3"/>
 </android.support.v4.widget.DrawerLayout>

--- a/src/com/todotxt/todotxttouch/RelativeLayoutCheckable.java
+++ b/src/com/todotxt/todotxttouch/RelativeLayoutCheckable.java
@@ -2,6 +2,7 @@ package com.todotxt.todotxttouch;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.View;
 import android.widget.Checkable;
 import android.widget.RelativeLayout;
 
@@ -23,10 +24,14 @@ public class RelativeLayoutCheckable extends RelativeLayout implements Checkable
 	    @Override
 	    public void setChecked(boolean checked) {
 	        this.checked = checked; 
-
-	        this.setBackgroundColor(checked ? getResources().getColor(R.color.activated_background) : getResources().getColor(R.color.grey));
-	        //FIXME: this is a hack to get a grey background when swiping without breaking highlight when selected:
-	        this.findViewById(R.id.swipe_view).setBackgroundColor(checked ? getResources().getColor(android.R.color.transparent) : getResources().getColor(R.color.white));
+	        View swipeView = this.findViewById(R.id.swipe_view);
+	        if (swipeView != null) {
+	            //FIXME: this is a hack to get a grey background when swiping without breaking highlight when selected:
+	            this.setBackgroundColor(checked ? getResources().getColor(R.color.activated_background) : getResources().getColor(R.color.grey));
+	            swipeView.setBackgroundColor(checked ? getResources().getColor(android.R.color.transparent) : getResources().getColor(R.color.white));
+	        } else {
+	            this.setBackgroundColor(checked ? getResources().getColor(R.color.activated_background) : getResources().getColor(android.R.color.transparent));
+	        }
 	    }
 
 	    @Override

--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -342,9 +342,11 @@ public class TodoTxtTouch extends SherlockListActivity implements
 			getSupportActionBar().setHomeButtonEnabled(false);
 		} else {
 			m_drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED, Gravity.LEFT);
+			m_drawerList.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
 			m_drawerList.setAdapter(new ArrayAdapter<String>(this,
-				R.layout.drawer_list_item, m_lists));
-
+				R.layout.drawer_list_item, R.id.left_drawer_text, m_lists));
+			setDrawerChoices();
+			
 			// Set the list's click listener
 			m_drawerList.setOnItemClickListener(new DrawerItemClickListener());
 
@@ -917,6 +919,7 @@ public class TodoTxtTouch extends SherlockListActivity implements
 				m_search = data.getStringExtra(Constants.EXTRA_SEARCH);
 				m_filters = data
 						.getStringArrayListExtra(Constants.EXTRA_APPLIED_FILTERS);
+				setDrawerChoices();
 				setFilteredTasks(false);
 			}
 		} else if (requestCode == REQUEST_PREFERENCES) {
@@ -1277,6 +1280,7 @@ public class TodoTxtTouch extends SherlockListActivity implements
 		m_projects = new ArrayList<String>(); // Collections.emptyList();
 		m_filters = new ArrayList<String>();
 		m_search = "";
+		setDrawerChoices();
 	}
 
 	void setFilteredTasks(boolean reload) {
@@ -1531,26 +1535,58 @@ public class TodoTxtTouch extends SherlockListActivity implements
 		@Override
 		public void onItemClick(AdapterView<?> parent, View view, int position,
 				long id) {
-			TextView tv = (TextView) view;
+			TextView tv = (TextView) view.findViewById(R.id.left_drawer_text);
 			String itemTitle = tv.getText().toString();
 			Log.v(TAG, "Clicked on drawer " + itemTitle);
-			if (itemTitle.substring(0, 1).equals("@")) {
+			if (itemTitle.substring(0, 1).equals("@") && !m_contexts.remove(itemTitle.substring(1))) {
 				m_contexts = new ArrayList<String>();
 				m_contexts.add(itemTitle.substring(1));
-				if (!m_filters
-						.contains(getString(R.string.filter_tab_contexts))) {
-					m_filters.add(getString(R.string.filter_tab_contexts));
-				}
-			} else {
+			} else if (itemTitle.substring(0, 1).equals("+") && !m_projects.remove(itemTitle.substring(1))) {
 				m_projects = new ArrayList<String>();
 				m_projects.add(itemTitle.substring(1));
-				if (!m_filters
-						.contains(getString(R.string.filter_tab_projects))) {
-					m_filters.add(getString(R.string.filter_tab_projects));
-				}
 			}
+			
+			setDrawerChoices();
 			m_drawerLayout.closeDrawer(m_drawerList);
 			setFilteredTasks(false);
 		}
+	}
+	
+	private void setDrawerChoices() {
+		m_drawerList.clearChoices();
+		boolean haveContexts = false;
+		boolean haveProjects = false;
+
+		for(int i = 0; i < m_lists.size(); i++) {
+			String item = m_lists.get(i).substring(1);
+			if(m_contexts.contains(item)) {
+				m_drawerList.setItemChecked(i, true);
+				haveContexts = true;
+			}
+			else if(m_projects.contains(item)) {
+				m_drawerList.setItemChecked(i, true);
+				haveProjects = true;
+			}
+		}
+		
+		if(haveContexts) {
+			if (!m_filters
+					.contains(getString(R.string.filter_tab_contexts))) {
+				m_filters.add(getString(R.string.filter_tab_contexts));
+			}
+		} else {
+			m_filters.remove(getString(R.string.filter_tab_contexts));
+		}
+
+		if(haveProjects) {
+			if (!m_filters
+					.contains(getString(R.string.filter_tab_projects))) {
+				m_filters.add(getString(R.string.filter_tab_projects));
+			}
+		} else {
+			m_filters.remove(getString(R.string.filter_tab_projects));
+		}
+
+		((ArrayAdapter<?>)m_drawerList.getAdapter()).notifyDataSetChanged();
 	}
 }


### PR DESCRIPTION
Changed drawer style to match the rest of the app. Also added highlighting so you can see what is already selected. Clicking an already selected filter will unselect it. I believe this makes it more clear that you can select only one project AND one context at a time. Previously I was confused when clicking on a project that the previously selected context was still active.

![2013-06-30 02 05 04](https://f.cloud.github.com/assets/792147/726999/7c7ee70e-e153-11e2-8731-ed1907095174.png)
