### PR TITLE
Fix relative dates

### DIFF
--- a/tests/src/com/todotxt/todotxttouch/util/RelativeDateTest.java
+++ b/tests/src/com/todotxt/todotxttouch/util/RelativeDateTest.java
@@ -1,0 +1,140 @@
+/**
+ * This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
+ *
+ * Copyright (c) 2009-2013 Todo.txt contributors (http://todotxt.com)
+ *
+ * LICENSE:
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2013 Todo.txt contributors (http://todotxt.com)
+ */
+package com.todotxt.todotxttouch.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import android.test.InstrumentationTestCase;
+
+import com.todotxt.todotxttouch.R;
+
+public class RelativeDateTest extends InstrumentationTestCase {
+	
+	private static SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+	
+	private String res(int resId) {
+		return getInstrumentation().getTargetContext().getString(resId);
+	}
+
+	private String res(int resId, int val) {
+		return getInstrumentation().getTargetContext().getString(resId, val);
+	}
+
+	private Calendar date(String str) {
+		try {
+			Date d = sdf.parse(str);
+			Calendar calendar = GregorianCalendar.getInstance();
+			calendar.setTime(d);
+			return calendar;
+		} catch (ParseException e) {
+			e.printStackTrace();
+			fail();
+			return null;
+		}
+	}
+	
+	public void testNow() {
+		Calendar today = new GregorianCalendar();
+		today.set(GregorianCalendar.HOUR_OF_DAY, 0);
+		today.set(GregorianCalendar.MINUTE, 0);
+		today.set(GregorianCalendar.SECOND, 0);
+		today.set(GregorianCalendar.MILLISECOND,0);
+		String actual = RelativeDate.getRelativeDate(today, today);
+		assertEquals(res(R.string.dates_today), actual);
+	}
+
+	public void test1DayFromNow() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2013-01-02");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals("2013-01-02", actual);
+	}
+
+	public void testToday() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2013-01-01");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_today), actual);
+	}
+
+	public void test1DayAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-12-31");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_one_day_ago), actual);
+	}
+
+	public void test2DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-12-30");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_days_ago, 2), actual);
+	}
+
+	public void test29DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-12-03");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_days_ago, 29), actual);
+	}
+
+	public void test30DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-12-02");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_one_month_ago), actual);
+	}
+
+	public void test59DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-11-03");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_one_month_ago), actual);
+	}
+
+	public void test60DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-11-02");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_months_ago, 2), actual);
+	}
+
+	public void test364DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-01-03");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals(res(R.string.dates_months_ago, 12), actual);
+	}
+
+	public void test365DaysAgo() {
+		Calendar d1 = date("2013-01-01");
+		Calendar d2 = date("2012-01-02");
+		String actual = RelativeDate.getRelativeDate(d1, d2);
+		assertEquals("2012-01-02", actual);
+	}
+
+}


### PR DESCRIPTION
Simplified the RelativeDate logic to the following:

```
if date is in future or more than 365 days in past, just display the date in yyyy-mm-dd format.

else if date is more than 30 days in the past, display 'N months ago', where 1 month is considered 30 days. 
This isn't very accurate, but it should be good enough for our purpose here.

else if date is more than 1 day in the past, display 'N days ago'

else display 'today'.
```

Fixes #289
