### PR TITLE
Combine Manual and Automatic Sync Preferences

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -53,9 +53,6 @@
   <string name="line_breaks_pref_key">linebreakspref</string>
   <string name="line_breaks_pref_title">Zalamování řádků jako ve Windows</string>
   <string name="line_breaks_pref_summary">Zalamovat řádky v textovém souboru jako v systému Windows.</string>
-  <string name="manual_sync_pref_key">workofflinepref</string>
-  <string name="manual_sync_pref_title">Ruční synchronizace</string>
-  <string name="manual_sync_pref_summary">Nenahrávat každou změnu do Dopboxu automaticky.</string>
   <string name="sync_dialog_title">Ruční synchronizace</string>
   <string name="sync_dialog_msg">Chcete nahrát nebo stáhnout soubor todo.txt?</string>
   <string name="sync_dialog_upload">Nahrát do Dropboxu</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -50,9 +50,6 @@
   <string name="line_breaks_pref_key">linebreakspref</string>
   <string name="line_breaks_pref_title">Windows Zeilenenden</string>
   <string name="line_breaks_pref_summary">Benutze Windows-freundliche Zeilenenden in der Textdatei.</string>
-  <string name="manual_sync_pref_key">workofflinepref</string>
-  <string name="manual_sync_pref_title">Manuelle Syncronisierung</string>
-  <string name="manual_sync_pref_summary">Lade nicht automatisch jede Änderung zu Dropbox.</string>
   <string name="sync_dialog_title">Manueller Sync</string>
   <string name="sync_dialog_msg">Möchten Sie die todo.txt-Datei hoch- oder runterladen?</string>
   <string name="sync_dialog_upload">Änderungen hochladen</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -52,9 +52,6 @@
   <string name="line_breaks_pref_key">linebreakspref</string>
   <string name="line_breaks_pref_title">Saut de ligne Windows</string>
   <string name="line_breaks_pref_summary">Utiliser le saut de ligne Windows dans le fichier texte.</string>
-  <string name="manual_sync_pref_key">workofflinepref</string>
-  <string name="manual_sync_pref_title">Synchronisation manuelle</string>
-  <string name="manual_sync_pref_summary">Ne pas téléverser tous les changements à Dropbox automatiquement.</string>
   <string name="sync_dialog_title">Synchronisation manuelle</string>
   <string name="sync_dialog_msg">Voulez-vous envoyer ou recevoir votre fichier todo.txt ?</string>
   <string name="sync_dialog_upload">Envoyer sur Dropbox</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -54,9 +54,6 @@
   <string name="line_breaks_pref_key">linebreakspref</string>
   <string name="line_breaks_pref_title">Compatibilità Windows</string>
   <string name="line_breaks_pref_summary">Nei file di testo usa un terminatore di riga compatibile con Windows.</string>
-  <string name="manual_sync_pref_key">workofflinepref</string>
-  <string name="manual_sync_pref_title">Sincronizza manualmente</string>
-  <string name="manual_sync_pref_summary">Non sincronizzare automaticamente su Dropbox ogni modifica effettuata.</string>
   <string name="sync_dialog_title">Sincronizza manualmente</string>
   <string name="sync_dialog_msg">Vuoi sincronizzare o scaricare il tuo file todo.txt?</string>
   <string name="sync_dialog_upload">Sincronizza su Dropbox</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -53,9 +53,6 @@
   <string name="line_breaks_pref_key">настройки перевода строки</string>
   <string name="line_breaks_pref_title">Символы переноса строк Windows</string>
   <string name="line_breaks_pref_summary">Использовать в текстовом файле символы переноса строк Windows.</string>
-  <string name="manual_sync_pref_key">workofflinepref</string>
-  <string name="manual_sync_pref_title">Ручная синхронизация</string>
-  <string name="manual_sync_pref_summary">Не загружать автоматически каждое изменение в Dropbox.</string>
   <string name="sync_dialog_title">Ручная синхронизация</string>
   <string name="sync_dialog_msg">Хотите загрузить или выгрузить ваш todo.txt файл?</string>
   <string name="sync_dialog_upload">Выгрузить в Dropbox</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -33,6 +33,7 @@ You should have received a copy of the GNU General Public License along with Tod
 	
 	<string-array name="periodic_sync_lengths">
 	    <item>Never</item>
+		<item>When app is running</item>
 		<item>Every 15 minutes</item>
 		<item>Every hour</item>
 		<item>Twice a day</item>
@@ -40,6 +41,7 @@ You should have received a copy of the GNU General Public License along with Tod
 	</string-array>
 	
 	<string-array name="periodic_sync_values"> <!-- values from AlarmManager.INTERVAL_* -->
+		<item>-1</item>
 		<item>0</item>
 		<item>900000</item>
 		<item>3600000</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -94,9 +94,6 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="line_breaks_pref_key">linebreakspref</string>
     <string name="line_breaks_pref_title">Windows line breaks</string>
     <string name="line_breaks_pref_summary">Use Windows-friendly line breaks in the text file.</string>
-    <string name="manual_sync_pref_key">workofflinepref</string>
-    <string name="manual_sync_pref_title">Manual sync</string>
-    <string name="manual_sync_pref_summary">Don\'t automatically upload every change to Dropbox.</string>
     <string name="periodic_sync_pref_key">sync_period</string>
     <string name="periodic_sync_pref_title">Automatic sync</string>
 

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -44,8 +44,6 @@
 		<EditTextPreference android:summary="@string/TODOTXTPATH_summary"
 			android:defaultValue="@string/TODOTXTPATH_defaultPath" android:title="@string/TODOTXTPATH_title"
 			android:key="@string/TODOTXTPATH_key" />
-		<CheckBoxPreference android:key="@string/manual_sync_pref_key"
-			android:title="@string/manual_sync_pref_title" android:summary="@string/manual_sync_pref_summary" />
 		<ListPreference android:key="@string/periodic_sync_pref_key"
 		    android:title="@string/periodic_sync_pref_title" android:entries="@array/periodic_sync_lengths"
 		    android:entryValues="@array/periodic_sync_values" android:defaultValue="0" />

--- a/src/com/todotxt/todotxttouch/Constants.java
+++ b/src/com/todotxt/todotxttouch/Constants.java
@@ -29,7 +29,6 @@ public class Constants {
 	public static final String PREF_ACCESSTOKEN_SECRET = "accesstokensecret";
 	public static final String PREF_TODO_REV = "todo_rev";
 	public static final String PREF_DONE_REV = "done_rev";
-	public static final String PREF_MANUAL_MODE = "workofflinepref";
 	public static final String PREF_NEED_TO_PUSH = "need_to_push";
 	public static final String PREF_PERIODIC_SYNC = "sync_period";
 	public static final String DROPBOX_MODUS = "dropbox";

--- a/src/com/todotxt/todotxttouch/Preferences.java
+++ b/src/com/todotxt/todotxttouch/Preferences.java
@@ -43,7 +43,6 @@ public class Preferences extends PreferenceActivity {
 	private Preference aboutDialog;
 	private Preference logoutDialog;
 	private ListPreference periodicSync;
-	private CheckBoxPreference manualOnly;
 	private static final int ABOUT_DIALOG = 1;
 	private static final int LOGOUT_DIALOG = 2;
 	public static final int RESULT_SYNC_LIST = 2;
@@ -76,7 +75,6 @@ public class Preferences extends PreferenceActivity {
 		aboutDialog = findPreference("app_version");
 		logoutDialog = findPreference("logout_dropbox");
 		periodicSync = (ListPreference) findPreference(getString(R.string.periodic_sync_pref_key));
-		manualOnly = (CheckBoxPreference) findPreference(getString(R.string.manual_sync_pref_key));
 		setPeriodicSummary(periodicSync.getValue());
 		periodicSync
 				.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
@@ -115,11 +113,6 @@ public class Preferences extends PreferenceActivity {
 			showDialog(ABOUT_DIALOG);
 		} else if (preference == logoutDialog) {
 			showDialog(LOGOUT_DIALOG);
-		} else if (preference == manualOnly) {
-			// When manual sync gets checked we want don't want periodic sync
-			periodicSync.setEnabled(!manualOnly.isChecked());
-			periodicSync.setValue("0"); // Disable
-			setPeriodicSummary(periodicSync.getValue());
 		}
 		return true;
 	}

--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -164,7 +164,13 @@ public class TodoApplication extends Application {
 	}
 
 	public boolean isManualMode() {
-		return m_prefs.getBoolean(Constants.PREF_MANUAL_MODE, false);
+		try {
+			long period = Long.parseLong(m_prefs.getString(
+					Constants.PREF_PERIODIC_SYNC, "0"));
+			return period < 0;
+		} catch (NumberFormatException ex) {
+			return false;
+		}
 	}
 
 	public boolean needToPush() {
@@ -352,13 +358,14 @@ public class TodoApplication extends Application {
 		sendBroadcast(intent);
 	}
 
-    public long getSyncPeriod() {
-        try {
-            long period = Long.parseLong(m_prefs.getString(Constants.PREF_PERIODIC_SYNC, "0"));
-            return period;
-        } catch (NumberFormatException ex) {
-            return 0L;
-        }
-    }
+	public long getSyncPeriod() {
+		try {
+			long period = Long.parseLong(m_prefs.getString(
+					Constants.PREF_PERIODIC_SYNC, "0"));
+			return period > 0 ? period : 0;
+		} catch (NumberFormatException ex) {
+			return 0L;
+		}
+	}
 
 }


### PR DESCRIPTION
Continuing the mission to rid the world of lengthy preference screens, I figured we can remove the Manual Sync preference and make it an entry in the Automatic Sync list. Now `Never` is the same as manual sync, and `When app is running` is the default setting where syncing is done automatically but not periodically in the background. The text could probably be better. Also, there are no translations for any of the sync periods selections.
