### PR TITLE
Cleanup and force refresh after changing file location

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -39,10 +39,10 @@
   <string name="dropbox_logout_pref_title">Odhlásit</string>
   <string name="dropbox_logout_pref_summary">Odhlásit z Dropboxu.</string>
   <string name="dropbox_logout_explainer">Opravdu se chcete odhlásit z Dropboxu?</string>
-  <string name="TODOTXTPATH_title">Umístění souboru</string>
-  <string name="TODOTXTPATH_summary">Dropbox složka, ve které je soubor todo.txt uložen.</string>
-  <string name="TODOTXTPATH_defaultPath">/todo</string>
-  <string name="DROPBOX_settings_header">Dropbox</string>
+  <string name="todo_path_title">Umístění souboru</string>
+  <string name="todo_path_summary">Dropbox složka, ve které je soubor todo.txt uložen.</string>
+  <string name="todo_path_default">/todo</string>
+  <string name="dropbox_settings_header">Dropbox</string>
   <string name="todotxt_settings_header">todo.txt</string>
   <string name="about_settings_header">O programu</string>
   <string name="prepend_date_pref_title">Datovaní nových úkolů</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -36,10 +36,10 @@
   <string name="dropbox_logout_pref_title">Ausloggen</string>
   <string name="dropbox_logout_pref_summary">Aus Dropbox ausloggen.</string>
   <string name="dropbox_logout_explainer">Wollen Sie sich wirklich aus Dropbox ausloggen?</string>
-  <string name="TODOTXTPATH_title">Ort der Datei</string>
-  <string name="TODOTXTPATH_summary">Der Dropbox Ordner in dem todo.txt gespeichert wird.</string>
-  <string name="TODOTXTPATH_defaultPath">/todo</string>
-  <string name="DROPBOX_settings_header">Dropbox</string>
+  <string name="todo_path_title">Ort der Datei</string>
+  <string name="todo_path_summary">Der Dropbox Ordner in dem todo.txt gespeichert wird.</string>
+  <string name="todo_path_default">/todo</string>
+  <string name="dropbox_settings_header">Dropbox</string>
   <string name="todotxt_settings_header">todo.txt</string>
   <string name="about_settings_header">Über</string>
   <string name="prepend_date_pref_title">Neue Tasks mit Datum</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -38,10 +38,10 @@
   <string name="dropbox_logout_pref_title">Se déconnecter</string>
   <string name="dropbox_logout_pref_summary">Se déconnecter de Dropbox.</string>
   <string name="dropbox_logout_explainer">Etes-vous sûr de vouloir vous déconnecter de Dropbox?</string>
-  <string name="TODOTXTPATH_title">Emplacement du fichier</string>
-  <string name="TODOTXTPATH_summary">Le dossier Dropbox où est placé todo.txt.</string>
-  <string name="TODOTXTPATH_defaultPath">/todo</string>
-  <string name="DROPBOX_settings_header">Dropbox</string>
+  <string name="todo_path_title">Emplacement du fichier</string>
+  <string name="todo_path_summary">Le dossier Dropbox où est placé todo.txt.</string>
+  <string name="todo_path_default">/todo</string>
+  <string name="dropbox_settings_header">Dropbox</string>
   <string name="todotxt_settings_header">todo.txt</string>
   <string name="about_settings_header">A propos</string>
   <string name="prepend_date_pref_title">Dater les nouvelles tâches</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -40,10 +40,10 @@
   <string name="dropbox_logout_pref_title">Disconnetti</string>
   <string name="dropbox_logout_pref_summary">Disconnetti da Dropbox.</string>
   <string name="dropbox_logout_explainer">Sei sicuro di volerti disconnettere da Dropbox?</string>
-  <string name="TODOTXTPATH_title">Cartella di destinazione</string>
-  <string name="TODOTXTPATH_summary">La cartella di Dropbox dove salvare todo.txt.</string>
-  <string name="TODOTXTPATH_defaultPath">/todo</string>
-  <string name="DROPBOX_settings_header">Dropbox</string>
+  <string name="todo_path_title">Cartella di destinazione</string>
+  <string name="todo_path_summary">La cartella di Dropbox dove salvare todo.txt.</string>
+  <string name="todo_path_default">/todo</string>
+  <string name="dropbox_settings_header">Dropbox</string>
   <string name="todotxt_settings_header">todo.txt</string>
   <string name="about_settings_header">Informazioni</string>
   <string name="prepend_date_pref_title">Datare nuove attività</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -53,10 +53,10 @@ You should have received a copy of the GNU General Public License along with Tod
 	<string name="dropbox_logout_pref_title">ログアウト</string>
 	<string name="dropbox_logout_pref_summary">Dropbox からログアウトします。</string>
 	<string name="dropbox_logout_explainer">本当に Dropbox からログアウトしてよろしいですか?</string>
-	<string name="TODOTXTPATH_title">ファイルの場所</string>
-	<string name="TODOTXTPATH_summary">todo.txt ファイルを置く Dropbox 上のフォルダを指定します。</string>
-	<string name="TODOTXTPATH_defaultPath">/todo</string>
-	<string name="DROPBOX_settings_header">Dropbox</string>
+	<string name="todo_path_title">ファイルの場所</string>
+	<string name="todo_path_summary">todo.txt ファイルを置く Dropbox 上のフォルダを指定します。</string>
+	<string name="todo_path_default">/todo</string>
+	<string name="dropbox_settings_header">Dropbox</string>
 	<string name="todotxt_settings_header">todo.txt</string>
 	<string name="about_settings_header">About</string>
 

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -39,10 +39,10 @@
   <string name="dropbox_logout_pref_title">Выйти</string>
   <string name="dropbox_logout_pref_summary">Выйти из Dropbox.</string>
   <string name="dropbox_logout_explainer">Вы уверены что хотите выйти из Dropbox?</string>
-  <string name="TODOTXTPATH_title">Местонахождение файла</string>
-  <string name="TODOTXTPATH_summary">Папка Dropbox где хранится файл todo.txt.</string>
-  <string name="TODOTXTPATH_defaultPath">/сделать</string>
-  <string name="DROPBOX_settings_header">Dropbox</string>
+  <string name="todo_path_title">Местонахождение файла</string>
+  <string name="todo_path_summary">Папка Dropbox где хранится файл todo.txt.</string>
+  <string name="todo_path_default">/сделать</string>
+  <string name="dropbox_settings_header">Dropbox</string>
   <string name="todotxt_settings_header">сделать.txt</string>
   <string name="about_settings_header">О программе</string>
   <string name="prepend_date_pref_title">Добавление даты новым заданиям</string>

--- a/res/values/keys.xml
+++ b/res/values/keys.xml
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License along with Tod
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string name="auto_archive_pref_key">todotxtautoarchive</string>
-    <string name="TODOTXTPATH_key">todotxtpath</string>
+    <string name="todo_path_key">todotxtpath</string>
     <string name="prepend_date_pref_key">todotxtprependdate</string>
     <string name="periodic_sync_pref_key">sync_period</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -80,10 +80,13 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="dropbox_logout_pref_title">Log out</string>
     <string name="dropbox_logout_pref_summary">Disconnect from Dropbox.</string>
     <string name="dropbox_logout_explainer">Are you sure you wish to log out of Dropbox?</string>
-    <string name="TODOTXTPATH_title">File location</string>
-    <string name="TODOTXTPATH_summary">The Dropbox folder where todo.txt is stored.</string>
-    <string name="TODOTXTPATH_defaultPath">/todo</string>
-    <string name="DROPBOX_settings_header">Dropbox</string>
+    <string name="dropbox_logout_warning">You have local changes to your todo.txt file! If you log out, they will be lost!</string>
+    <string name="todo_path_title">File location</string>
+    <string name="todo_path_summary">The Dropbox folder where todo.txt is stored.</string>
+    <string name="todo_path_warning">\n\nYou have local changes to your todo.txt file! If you change the file location, they will be lost!</string>
+    <string name="todo_path_warning_override">I\'m feeling dangerous!</string>
+    <string name="todo_path_default">/todo</string>
+    <string name="dropbox_settings_header">Dropbox</string>
     <string name="todotxt_settings_header">todo.txt</string>
     <string name="about_settings_header">About</string>
     <string name="prepend_date_pref_title">Date new tasks</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -38,10 +38,10 @@
 	</PreferenceCategory>
 
 	<PreferenceCategory android:key="dropbox_settings"
-		android:title="@string/DROPBOX_settings_header">
-		<EditTextPreference android:summary="@string/TODOTXTPATH_summary"
-			android:defaultValue="@string/TODOTXTPATH_defaultPath" android:title="@string/TODOTXTPATH_title"
-			android:key="@string/TODOTXTPATH_key" />
+		android:title="@string/dropbox_settings_header">
+		<com.todotxt.todotxttouch.TodoLocationPreference android:summary="@string/todo_path_summary"
+			android:defaultValue="@string/todo_path_default" android:title="@string/todo_path_title"
+			android:key="@string/todo_path_key" />
 		<ListPreference android:key="@string/periodic_sync_pref_key"
 		    android:title="@string/periodic_sync_pref_title" android:entries="@array/periodic_sync_lengths"
 		    android:entryValues="@array/periodic_sync_values" android:defaultValue="0" />

--- a/src/com/todotxt/todotxttouch/TodoLocationPreference.java
+++ b/src/com/todotxt/todotxttouch/TodoLocationPreference.java
@@ -1,0 +1,152 @@
+package com.todotxt.todotxttouch;
+
+import android.app.AlertDialog.Builder;
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.preference.EditTextPreference;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.EditText;
+
+public class TodoLocationPreference extends EditTextPreference {
+
+	private boolean mWarningMode = false;
+	private boolean mDisplayWarning = false;
+
+	public TodoLocationPreference(Context context) {
+		super(context);
+	}
+
+	public TodoLocationPreference(Context context, AttributeSet attrs) {
+		super(context, attrs);
+	}
+
+	public TodoLocationPreference(Context context, AttributeSet attrs,
+			int defStyle) {
+		super(context, attrs, defStyle);
+	}
+
+	public boolean shouldDisplayWarning() {
+		return mDisplayWarning;
+	}
+
+	public void setDisplayWarning(boolean shouldDisplay) {
+		mDisplayWarning = shouldDisplay;
+	}
+
+	private CharSequence getWarningMessage() {
+		SpannableString ss = new SpannableString(getContext().getString(R.string.todo_path_warning));
+		ss.setSpan(new ForegroundColorSpan(Color.RED), 0, ss.length(),
+				Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+		return ss;
+	}
+
+	@Override
+	protected void onPrepareDialogBuilder(Builder builder) {
+		// Display the warning message if necessary.
+		// Otherwise, just use the default layout.
+		EditText view = this.getEditText();
+		if (mWarningMode) {
+			view.setEnabled(false);
+			view.setVisibility(View.GONE);
+			builder.setMessage(getWarningMessage());
+			builder.setPositiveButton(R.string.todo_path_warning_override, this);
+		} else {
+			view.setVisibility(View.VISIBLE);
+			view.setEnabled(true);
+		}
+	}
+
+	protected boolean needInputMethod() {
+		// We want the input method to show, if possible, when edit dialog is
+		// displayed, but not when warning message is displayed
+		return !mWarningMode;
+	}
+
+	@Override
+	protected void onClick() {
+		// Called when the preference is clicked
+		// This method displays the dialog.
+		// When mDisplayWarning is set, we want to display
+		// a warning message instead of the actual dialog
+		mWarningMode = mDisplayWarning;
+		super.onClick();
+	}
+
+	@Override
+	protected void onDialogClosed(boolean positiveResult) {
+		// If we are displaying the warning message and the user
+		// clicked "I'm feeling dangerous", then redisplay the
+		// dialog with the default layout
+		if (mWarningMode && positiveResult) {
+			mWarningMode = false;
+			showDialog(null);
+			return;
+		}
+
+		// If we are already displaying the default layout
+		// do the default processing (either persist the change
+		// or cancel, depending on which button was pressed)
+		super.onDialogClosed(positiveResult);
+	}
+
+	@Override
+	protected Parcelable onSaveInstanceState() {
+		final Parcelable superState = super.onSaveInstanceState();
+
+		final SavedState myState = new SavedState(superState);
+		myState.warningMode = mWarningMode;
+		return myState;
+	}
+
+	@Override
+	protected void onRestoreInstanceState(Parcelable state) {
+		if (state == null || !state.getClass().equals(SavedState.class)) {
+			// Didn't save state for us in onSaveInstanceState
+			super.onRestoreInstanceState(state);
+			return;
+		}
+
+		SavedState myState = (SavedState) state;
+		mWarningMode = myState.warningMode;
+		super.onRestoreInstanceState(myState.getSuperState());
+	}
+
+	private static class SavedState extends BaseSavedState {
+		boolean warningMode;
+
+		public SavedState(Parcel source) {
+			super(source);
+			boolean[] array = new boolean[1];
+			source.readBooleanArray(array);
+			warningMode = array[0];
+		}
+
+		@Override
+		public void writeToParcel(Parcel dest, int flags) {
+			super.writeToParcel(dest, flags);
+			dest.writeBooleanArray(new boolean[]{warningMode});
+		}
+
+		public SavedState(Parcelable superState) {
+			super(superState);
+		}
+
+		@SuppressWarnings("unused")
+		public static final Parcelable.Creator<SavedState> CREATOR = new Parcelable.Creator<SavedState>() {
+			public SavedState createFromParcel(Parcel in) {
+				return new SavedState(in);
+			}
+
+			public SavedState[] newArray(int size) {
+				return new SavedState[size];
+			}
+		};
+	}
+
+}

--- a/src/com/todotxt/todotxttouch/TodoPreferences.java
+++ b/src/com/todotxt/todotxttouch/TodoPreferences.java
@@ -58,14 +58,14 @@ public class TodoPreferences {
 	public static final String PREF_FILTER_SUMMARY = "filter_summary";
 
 	/* Localizable defaults that should be defined in strings.xml */
-	private String TODOTXTPATH_defaultPath;
+	private String todo_path_default;
 
 	/*
 	 * Keys that are used in resources should be defined in keys.xml and read
 	 * into variables in the constructor
 	 */
 	private String auto_archive_pref_key;
-	private String TODOTXTPATH_key;
+	private String todo_path_key;
 	private String prepend_date_pref_key;
 	private String periodic_sync_pref_key;
 
@@ -75,11 +75,18 @@ public class TodoPreferences {
 		auto_archive_pref_key = c.getString(R.string.auto_archive_pref_key);
 		periodic_sync_pref_key = c.getString(R.string.periodic_sync_pref_key);
 		prepend_date_pref_key = c.getString(R.string.prepend_date_pref_key);
-		TODOTXTPATH_key = c.getString(R.string.TODOTXTPATH_key);
-		TODOTXTPATH_defaultPath = c.getString(R.string.TODOTXTPATH_defaultPath);
+		todo_path_key = c.getString(R.string.todo_path_key);
+		todo_path_default = c.getString(R.string.todo_path_default);
 		//dump();
 	}
 
+
+	/*
+	 * 
+	 *  Accessor methods for preference keys go here 
+	 *
+	 */
+	
 	public String prepend_date_pref_key() {
 		return prepend_date_pref_key;
 	}
@@ -88,6 +95,17 @@ public class TodoPreferences {
 		return periodic_sync_pref_key;
 	}
 
+	public String todo_path_key() {
+		return todo_path_key;
+	}
+
+
+	/*
+	 * 
+	 *  Accessor methods for preference values go here 
+	 *
+	 */
+	
 	public String getAccessToken() {
 		return m_prefs.getString(PREF_ACCESSTOKEN_KEY, null);
 	}
@@ -221,7 +239,23 @@ public class TodoPreferences {
 	}
 
 	public String getTodoFilePath() {
-		return m_prefs.getString(TODOTXTPATH_key, TODOTXTPATH_defaultPath);
+		return m_prefs.getString(todo_path_key, todo_path_default);
+	}
+
+
+	/*
+	 * 
+	 *  Utility methods go here 
+	 *
+	 */
+
+	public void clearState() {
+		Editor editor = m_prefs.edit();
+		editor.remove(PREF_FIRSTRUN);
+		editor.remove(PREF_DONE_REV);
+		editor.remove(PREF_TODO_REV);
+		editor.remove(PREF_NEED_TO_PUSH);
+		editor.commit();
 	}
 
 	public void clear() {
@@ -230,6 +264,14 @@ public class TodoPreferences {
 		editor.commit();
 	}
 	
+	public void registerOnSharedPreferenceChangeListener (SharedPreferences.OnSharedPreferenceChangeListener listener) {
+		m_prefs.registerOnSharedPreferenceChangeListener(listener);
+	}
+
+	public void unregisterOnSharedPreferenceChangeListener (SharedPreferences.OnSharedPreferenceChangeListener listener) {
+		m_prefs.unregisterOnSharedPreferenceChangeListener(listener);
+	}
+
 	public void dump() {
 		Map<String, ?> keys = m_prefs.getAll();
 

--- a/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
+++ b/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
@@ -64,6 +64,7 @@ class LocalFileTaskRepository implements LocalTaskRepository {
 	@Override
 	public void purge() {
 		TODO_TXT_FILE.delete();
+		DONE_TXT_FILE.delete();
 	}
 
 	@Override

--- a/src/com/todotxt/todotxttouch/task/TaskBag.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBag.java
@@ -39,6 +39,8 @@ public interface TaskBag {
 
 	void reload();
 
+	void clear();
+
 	void addAsTask(String input);
 
 	void update(Task task);

--- a/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
+++ b/src/com/todotxt/todotxttouch/task/TaskBagImpl.java
@@ -120,6 +120,13 @@ class TaskBagImpl implements TaskBag {
 	}
 
 	@Override
+	public void clear() {
+		this.tasks = new ArrayList<Task>();
+		localRepository.purge();
+		lastReload = null;
+	}
+
+	@Override
 	public int size() {
 		return tasks.size();
 	}
@@ -312,5 +319,6 @@ class TaskBagImpl implements TaskBag {
 		}
 		return partialMatch;
 	}
+
 
 }

--- a/tests/src/com/todotxt/todotxttouch/test/TaskBagStub.java
+++ b/tests/src/com/todotxt/todotxttouch/test/TaskBagStub.java
@@ -112,4 +112,10 @@ public class TaskBagStub implements TaskBag {
 
 	}
 
+	@Override
+	public void clear() {
+		// TODO Auto-generated method stub
+		
+	}
+
 }


### PR DESCRIPTION
Delete todo file after logout and after changing Dropbox path.
Force a refresh after changing Dropbox path.
Display a warning message before logout or changing Dropbox path if there are local changes that haven't been pushed.
Renamed preference keys that violated our conventions.

Fixes #397
Partially fixes #353 (still need to redirect to login screen whenever not logged on)
