### PR TITLE
Added upgrade handling logic for migrating data to internal storage. 

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,15 +23,14 @@ You should have received a copy of the GNU General Public License along with Tod
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.todotxt.todotxttouch"
-    android:versionCode="52"
-    android:versionName="2.1" >
+    android:versionCode="53"
+    android:versionName="2.2-beta1" >
 
     <uses-sdk
         android:minSdkVersion="8"
         android:targetSdkVersion="17" />
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <supports-screens
         android:anyDensity="true"

--- a/src/com/todotxt/todotxttouch/TodoApplication.java
+++ b/src/com/todotxt/todotxttouch/TodoApplication.java
@@ -65,6 +65,13 @@ public class TodoApplication extends Application {
 		super.onCreate();
 		TodoApplication.appContext = getApplicationContext();
 		m_prefs = new TodoPreferences(appContext, PreferenceManager.getDefaultSharedPreferences(this));
+		
+		try {
+			new UpgradeHandler(this).run();
+		} catch(Exception e) {
+			Log.e(TAG, "Failed to run Uprade Tasks", e);
+		}
+		
 		remoteClientManager = new RemoteClientManager(this, m_prefs);
 		this.taskBag = TaskBagFactory.getTaskBag(this, m_prefs);
 

--- a/src/com/todotxt/todotxttouch/TodoPreferences.java
+++ b/src/com/todotxt/todotxttouch/TodoPreferences.java
@@ -45,6 +45,7 @@ public class TodoPreferences {
 	 * as constants
 	 */
 	public static final String PREF_FIRSTRUN = "firstrun";
+	public static final String PREF_VERSION = "versionCode";
 	public static final String PREF_ACCESSTOKEN_KEY = "accesstokenkey";
 	public static final String PREF_ACCESSTOKEN_SECRET = "accesstokensecret";
 	public static final String PREF_TODO_REV = "todo_rev";
@@ -242,6 +243,26 @@ public class TodoPreferences {
 		return m_prefs.getString(todo_path_key, todo_path_default);
 	}
 
+	/**
+	 * Returns the most recent version to have successfully run upgrade tasks.
+	 * Returns 0 if upgrade tasks have never been run.
+	 * @return version code in the same format as in the manifest file.
+	 */
+	public int getVersion() {
+		return m_prefs.getInt(PREF_VERSION, 0);
+	}
+
+	/**
+	 * Store the current application version so that we know
+	 * when we have been upgraded.
+	 * @param versionCode version code in the same format as in the manifest file.
+	 */
+	public void storeVersion(int versionCode) {
+		Editor editor = m_prefs.edit();
+		editor.putInt(PREF_VERSION, versionCode);
+		editor.commit();
+	}
+	
 	/*
 	 * 
 	 *  Utility methods go here 

--- a/src/com/todotxt/todotxttouch/UpgradeHandler.java
+++ b/src/com/todotxt/todotxttouch/UpgradeHandler.java
@@ -1,0 +1,129 @@
+/**
+ * This file is part of Todo.txt Touch, an Android app for managing your todo.txt file (http://todotxt.com).
+ *
+ * Copyright (c) 2009-2013 Todo.txt contributors (http://todotxt.com)
+ *
+ * LICENSE:
+ *
+ * Todo.txt Touch is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Todo.txt Touch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with Todo.txt Touch.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @author Todo.txt contributors <todotxt@yahoogroups.com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2013 Todo.txt contributors (http://todotxt.com)
+ */
+package com.todotxt.todotxttouch;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.todotxt.todotxttouch.util.Util;
+
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Environment;
+import android.util.Log;
+
+public class UpgradeHandler {
+	private static final String TAG = UpgradeHandler.class.getSimpleName();
+	
+	private TodoApplication mApp;
+	private int mCurVersion;
+	private int mPrevVersion;
+	List<UpgradeTask> mHandlers = new ArrayList<UpgradeTask>();
+
+	public UpgradeHandler(TodoApplication application) {
+		mApp = application;
+	}
+
+	public void run() throws NameNotFoundException {
+		mCurVersion = mApp.getPackageManager().getPackageInfo(
+				mApp.getPackageName(), 0).versionCode;
+		mPrevVersion = mApp.m_prefs.getVersion();
+		
+		if (mPrevVersion >= mCurVersion) {
+			Log.d(TAG, "No need to upgrade. Stored version is " + mPrevVersion + ". Cur version is "
+					+ mCurVersion);
+			return;
+		}
+		
+		Log.i(TAG, "Running upgrade tasks from " + mPrevVersion + " to "
+				+ mCurVersion);
+
+		initHandlers();
+		for (UpgradeTask handler : mHandlers) {
+			int version = handler.getVersion();
+			if (version > mPrevVersion && version <= mCurVersion) {
+				Log.i(TAG, "Running upgrade task: " + handler.getDescription());
+				handler.getRunnable().run();
+			}
+		}
+
+		mApp.m_prefs.storeVersion(mCurVersion);
+		Log.i(TAG, "Successfully upgraded to version " + mCurVersion);
+	}
+
+	final class UpgradeTask {
+		private String mDescription;
+		private int mVersion;
+		private Runnable mRunnable;
+
+		public UpgradeTask(String description, int version, Runnable runnable) {
+			mDescription = description;
+			mVersion = version;
+			mRunnable = runnable;
+		}
+
+		public String getDescription() {
+			return mDescription;
+		}
+
+		public int getVersion() {
+			return mVersion;
+		}
+
+		public Runnable getRunnable() {
+			return mRunnable;
+		}
+	}
+
+	void initHandlers() {
+		UpgradeTask up53 = new UpgradeTask(
+				"Migrate data from external to internal storage", 53,
+				new Runnable() {
+					@Override
+					public void run() {
+						File srcTodo = new File(Environment
+								.getExternalStorageDirectory(),
+								"data/com.todotxt.todotxttouch/todo.txt");
+						File srcDone = new File(Environment
+								.getExternalStorageDirectory(),
+								"data/com.todotxt.todotxttouch/done.txt");
+						File destTodo = new File(TodoApplication
+								.getAppContetxt().getFilesDir(), "todo.txt");
+						File destDone = new File(TodoApplication
+								.getAppContetxt().getFilesDir(), "done.txt");
+
+						if (srcTodo.exists() && !destTodo.exists()) {
+							Log.d(TAG, "Copying " + srcTodo + " to " + destTodo);
+							Util.copyFile(srcTodo, destTodo, false);
+						}
+
+						if (srcDone.exists() && !destDone.exists()) {
+							Log.d(TAG, "Copying " + srcDone + " to " + destDone);
+							Util.copyFile(srcDone, destDone, false);
+						}
+					}
+				});
+		mHandlers.add(up53);
+
+	}
+}

--- a/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
+++ b/src/com/todotxt/todotxttouch/remote/DropboxRemoteClient.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import android.content.Intent;
-import android.os.Environment;
 import android.util.Log;
 
 import com.dropbox.client2.DropboxAPI;
@@ -50,11 +49,11 @@ class DropboxRemoteClient implements RemoteClient {
 	private static final String DONE_TXT_REMOTE_FILE_NAME = "done.txt";
 	private static final AccessType ACCESS_TYPE = AccessType.DROPBOX;
 	private static final File TODO_TXT_TMP_FILE = new File(
-			Environment.getExternalStorageDirectory(),
-			"data/com.todotxt.todotxttouch/tmp/todo.txt");
+			TodoApplication.getAppContetxt().getFilesDir(),
+			"tmp/todo.txt");
 	private static final File DONE_TXT_TMP_FILE = new File(
-			Environment.getExternalStorageDirectory(),
-			"data/com.todotxt.todotxttouch/tmp/done.txt");
+			TodoApplication.getAppContetxt().getFilesDir(),
+			"tmp/done.txt");
 
 	private DropboxAPI<AndroidAuthSession> dropboxApi;
 	private TodoApplication todoApplication;

--- a/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
+++ b/src/com/todotxt/todotxttouch/task/LocalFileTaskRepository.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 
-import android.os.Environment;
 import android.util.Log;
 
+import com.todotxt.todotxttouch.TodoApplication;
 import com.todotxt.todotxttouch.TodoException;
 import com.todotxt.todotxttouch.util.TaskIo;
 import com.todotxt.todotxttouch.util.Util;
@@ -43,11 +43,11 @@ class LocalFileTaskRepository implements LocalTaskRepository {
 	private static final String TAG = LocalFileTaskRepository.class
 			.getSimpleName();
 	final static File TODO_TXT_FILE = new File(
-			Environment.getExternalStorageDirectory(),
-			"data/com.todotxt.todotxttouch/todo.txt");
+			TodoApplication.getAppContetxt().getFilesDir(),
+			"todo.txt");
 	final static File DONE_TXT_FILE = new File(
-			Environment.getExternalStorageDirectory(),
-			"data/com.todotxt.todotxttouch/done.txt");
+			TodoApplication.getAppContetxt().getFilesDir(),
+			"done.txt");
 
 	@Override
 	public void init() {

--- a/src/com/todotxt/todotxttouch/util/Util.java
+++ b/src/com/todotxt/todotxttouch/util/Util.java
@@ -24,9 +24,11 @@ package com.todotxt.todotxttouch.util;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -321,6 +323,35 @@ public class Util {
 			Log.e(TAG, "Error renaming " + origFile + " to " + newFile);
 			throw new TodoException("Error renaming " + origFile + " to "
 					+ newFile);
+		}
+	}
+
+	public static void copyFile(File origFile, File newFile, boolean overwrite) {
+		if (!origFile.exists()) {
+			Log.e(TAG, "Error renaming file: " + origFile + " does not exist");
+			throw new TodoException("Error copying file: " + origFile
+					+ " does not exist");
+		}
+
+		createParentDirectory(newFile);
+
+		if (!overwrite && newFile.exists()) {
+			Log.e(TAG, "Error copying file: destination exists: " + newFile);
+			throw new TodoException("Error copying file: destination exists: "
+					+ newFile);
+		}
+
+		try {
+			FileInputStream fis = new FileInputStream(origFile);
+			FileOutputStream fos = new FileOutputStream(newFile);
+			FileChannel in = fis.getChannel();
+			fos.getChannel().transferFrom(in, 0, in.size());
+			fis.close();
+			fos.close();
+		} catch (Exception e) {
+			Log.e(TAG, "Error copying " + origFile + " to " + newFile);
+			throw new TodoException("Error copying " + origFile + " to "
+					+ newFile, e);
 		}
 	}
 

--- a/tests/src/com/todotxt/todotxttouch/remote/DropboxFileDownloaderTest.java
+++ b/tests/src/com/todotxt/todotxttouch/remote/DropboxFileDownloaderTest.java
@@ -36,15 +36,15 @@ import org.apache.http.HttpVersion;
 import org.apache.http.impl.DefaultHttpResponseFactory;
 import org.apache.http.message.BasicStatusLine;
 
-import junit.framework.TestCase;
-import android.os.Environment;
+import android.test.ApplicationTestCase;
 
 import com.dropbox.client2.DropboxAPI;
 import com.dropbox.client2.ProgressListener;
 import com.dropbox.client2.exception.DropboxException;
 import com.dropbox.client2.exception.DropboxServerException;
+import com.todotxt.todotxttouch.TodoApplication;
 
-public class DropboxFileDownloaderTest extends TestCase {
+public class DropboxFileDownloaderTest extends ApplicationTestCase<TodoApplication> {
 	private static final String remotefile1 = "remotefile1";
 	private static final String remotefile2 = "remotefile2";
 	private static final String localpath1 = "data/com.todotxt.todotxttouch/tmp/test1.txt";
@@ -55,23 +55,30 @@ public class DropboxFileDownloaderTest extends TestCase {
 	private static final String origrev1 = "origrev1";
 	private static final String origrev2 = "origrev2";
 
-	private File localFile1 = new File(
-			Environment.getExternalStorageDirectory(), localpath1);
-	private File localFile2 = new File(
-			Environment.getExternalStorageDirectory(), localpath2);
-
+	private File localFile1;
+	private File localFile2;
 	DropboxFile dbFile1;
 	DropboxFile dbFile2;
 	ArrayList<DropboxFile> dropboxFiles1;
 	ArrayList<DropboxFile> dropboxFiles2;
 
+	public DropboxFileDownloaderTest(Class<TodoApplication> applicationClass) {
+		super(applicationClass);
+	}
+
 	protected void setUp() throws Exception {
+		createApplication();
+		
+		localFile1 = new File(TodoApplication.getAppContetxt().getFilesDir(), localpath1);
+		localFile2 = new File(TodoApplication.getAppContetxt().getFilesDir(), localpath2);
+
 		if (localFile1.exists()) {
 			localFile1.delete();
 		}
 		if (localFile2.exists()) {
 			localFile2.delete();
 		}
+		
 		dbFile1 = new DropboxFile(remotefile1, localFile1, origrev1);
 		dbFile2 = new DropboxFile(remotefile2, localFile2, origrev2);
 		dropboxFiles1 = new ArrayList<DropboxFile>(1);


### PR DESCRIPTION
The logic is generic and based on the application version, so it can be used for other upgrade tasks in the future.

Fixes #148 and #143.

I took a conservative approach here to avoid data loss. The data in external storage is copied to internal storage, but not deleted, in case the user wants to keep it around or if the app screws up and we need to migrate again.

Speaking of migrating again, this can be tested repeatedly by logging out and force-killing the application. The upgrade handler is only run at startup, and it will only run tasks that it hasn't run before. Logging out clears the version code out of shared preferences so it will run all tasks at the next launch. It also deletes the data from internal storage. Force-killing the app ensures that the upgrade handler runs the next time you launch the app.
