### PR TITLE
Added 'Add Reminder' menu item

### DIFF
--- a/res/menu/main_long.xml
+++ b/res/menu/main_long.xml
@@ -55,6 +55,11 @@ You should have received a copy of the GNU General Public License along with Tod
         android:showAsAction="never"
         android:title="@string/share"/>
     <item
+        android:id="@+id/calendar"
+        android:showAsAction="never"
+        android:title="@string/add_to_calendar"
+        android:enabled="@bool/api_14_or_above"/>
+    <item
         android:id="@+id/url"
         android:visible="false"/>
     <item

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -49,6 +49,8 @@ You should have received a copy of the GNU General Public License along with Tod
     <string name="update">Update</string>
     <string name="delete">Delete</string>
     <string name="share">Share</string>
+    <string name="add_to_calendar">Add reminder</string>
+    <string name="calendar_title">Todo.txt reminder</string>
     <string name="archive">Archive</string>
     <string name="unComplete">Undo complete</string>
     <string name="swipe_action_complete">Completed task.</string>

--- a/src/com/todotxt/todotxttouch/Constants.java
+++ b/src/com/todotxt/todotxttouch/Constants.java
@@ -53,4 +53,8 @@ public class Constants {
 	public final static String INTENT_SET_MANUAL = "com.todotxt.todotxttouch.GO_OFFLINE";
 	public final static String INTENT_UPDATE_UI = "com.todotxt.todotxttouch.UPDATE_UI";
 	public final static String INTENT_WIDGET_UPDATE = "com.todotxt.todotxttouch.APPWIDGET_UPDATE";
+
+	// Android OS specific constants
+	public static final String ANDROID_EVENT = "vnd.android.cursor.item/event";
+
 }

--- a/src/com/todotxt/todotxttouch/TodoTxtTouch.java
+++ b/src/com/todotxt/todotxttouch/TodoTxtTouch.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import uk.co.senab.actionbarpulltorefresh.extras.actionbarsherlock.PullToRefreshAttacher;
 import uk.co.senab.actionbarpulltorefresh.library.PullToRefreshAttacher.DefaultHeaderTransformer;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -51,7 +52,9 @@ import android.graphics.Paint;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.CalendarContract.Events;
 import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.widget.DrawerLayout;
 import android.text.SpannableString;
@@ -129,8 +132,6 @@ public class TodoTxtTouch extends SherlockListActivity implements
 
 	private boolean mListScrolling = false;
 
-	private LinearLayout m_tabletDrawerLayout;
-
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -195,7 +196,6 @@ public class TodoTxtTouch extends SherlockListActivity implements
 		// Setup Navigation drawer
 		m_drawerList = (ListView) findViewById(R.id.left_drawer);
 		m_drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
-		m_tabletDrawerLayout = (LinearLayout) findViewById(R.id.tablet_drawer_layout);
 
 		// Set the adapter for the list view
 		updateNavigationDrawer();
@@ -515,11 +515,16 @@ public class TodoTxtTouch extends SherlockListActivity implements
 		return true;
 	}
 
-	private void shareTasks(List<Task> tasks) {
-		String shareText = "";
+	private String selectedTasksAsString(List<Task> tasks) {
+		String text = "";
 		for (Task t : tasks) {
-			shareText += t.inFileFormat() + "\n";
+			text += t.inFileFormat() + "\n";
 		}
+		return text;
+	}
+	
+	private void shareTasks(List<Task> tasks) {
+		String shareText = selectedTasksAsString(tasks);
 		Intent shareIntent = new Intent(android.content.Intent.ACTION_SEND);
 		shareIntent.setType("text/plain");
 		shareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT,
@@ -530,6 +535,26 @@ public class TodoTxtTouch extends SherlockListActivity implements
 				getString(R.string.share_title)));
 	}
 
+	@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+	private void addToCalendar(List<Task> checkedTasks) {
+		Intent intent;
+		String calendarTitle = getString(R.string.calendar_title);
+		String calendarDescription = "";
+		if (checkedTasks.size() == 1) {
+			// Set the task as title
+			calendarTitle = checkedTasks.get(0).getText();
+		} else {
+			// Set the tasks as description
+			calendarDescription = selectedTasksAsString(checkedTasks);
+
+		}
+		intent = new Intent(android.content.Intent.ACTION_EDIT)
+				.setType(Constants.ANDROID_EVENT)
+				.putExtra(Events.TITLE, calendarTitle)
+				.putExtra(Events.DESCRIPTION, calendarDescription);
+		startActivity(intent);
+	}
+	
 	private void prioritizeTasks(final ArrayList<Task> tasks) {
 		final String[] prioArr = Priority
 				.rangeInCode(Priority.NONE, Priority.E).toArray(new String[0]);
@@ -1167,6 +1192,9 @@ public class TodoTxtTouch extends SherlockListActivity implements
 						break;
 					case R.id.share:
 						shareTasks(checkedTasks);
+						break;
+					case R.id.calendar:
+						addToCalendar(checkedTasks);
 						break;
 					case R.id.uncomplete:
 						undoCompleteTasks(checkedTasks, true);


### PR DESCRIPTION
Fixes #364. Taken pretty much 100% from @mpcjanssen's [simpletask](https://github.com/mpcjanssen/simpletask). The menu item is only available on devices with Android 4.0 and above because the Calendar API did not exist until API 14.
